### PR TITLE
Uefi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 2026-04-02
+
+### 🚀 Added
+- **Agnostic Bootloader Injection**: Introduced the `bootloaders_path` JSON parameter. `action_uefi` and `action_isolinux` can now dynamically pull bootloader binaries (like Debian's `grubx64.efi` and `isolinux.bin`) from an external path provided by the orchestrator, enabling universal booting for non-Debian host systems.
+- **Hybrid UEFI/BIOS ISO Master**: `action_iso` now automatically detects the presence of UEFI payloads and dynamically generates a 4MB FAT `efi.img` (via `dd`, `mkfs.vfat`, and loop mount) to inject into `xorriso` using the `-eltorito-alt-boot` flag.
+- **UEFI Trampoline Configuration**: Added a secondary `grub.cfg` inside the `EFI/BOOT/` directory to act as a trampoline. This redirects the firmware to the main `/boot/grub/grub.cfg` on the ISO9660 filesystem, completely avoiding the dreaded `grub rescue>` prompt.
+
+### 🛠 Changed
+- **Plan JSONs Updated**: All JSON templates (`plan-standard.json`, `plan-clone.json`, `plan-crypted.json`) have been updated to include the `bootloaders_path` key and the correct modern modular actions.
+- **Code Refactoring**: Removed the legacy monolithic `action_remaster` logic completely, distributing its responsibilities natively into `action_livestruct`, `action_isolinux`, and `action_uefi`.
+
+### 🐛 Fixed
+- **Missing GRUB Modules**: Fixed an issue in `action_uefi` where `*.mod` and `*.lst` files were not copied to the `x86_64-efi` directory, causing boot failures.
+
+### 📚 Documented
+- **Universal Strategy Manifesto**: Created `docs/UNIVERSAL_STRATEGY.md` outlining the 4 pillars of the *penguins-eggs* ecosystem (Debian Passepartout, Yocto-style identity, Initramfs abstraction, and the Orchestrator role).
+- **Architecture Guide Update**: Added details about the `tmpfs` Anti-Inception shield and dynamic `/home` handling to `docs/ARCHITECTURE.md`.
+- **Actions Reference**: Completely overhauled `docs/ACTIONS.md` to reflect the new C engine modules (added `cleanup`, `crypted`, `scan`, `suspend`).
+- **README and Roadmap**: Cleaned up `README.md`, moved future goals to a dedicated `docs/ROADMAP.md`, and added links to the philosophical architecture.
+
 ## [0.2.0] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ oa can execute complex workflows through a `plan.json`. This allows for a full r
 sudo ./oa plan.json
 ```
 
+## 🧠 Philosophy & Universal Strategy
+
+**oa** is not just a copy tool; it is the raw execution engine for a broader ecosystem (*penguins-eggs* and hopefully others). It achieves true distro-agnosticism (supporting Debian, Arch, RHEL, SUSE, Manjaro, etc.) by intentionally leaving the "thinking" to a higher-level orchestrator and relying on core architectural pillars like:
+1. **The "Debian Passepartout" Bootloader**
+2. **Yocto-Style Native Identity Forging**
+3. **The Initramfs Abstraction**
+4. **The "Eggs vs Bananas" Biological Diversity Paradigm**
+
+To fully understand the architecture and the strategy behind this engine, please read the [Universal Remastering Strategy](docs/UNIVERSAL_STRATEGY.md) and the [Architecture Guide](docs/ARCHITECTURE.md).
+
 ## 🗺 Roadmap
 
 The development goals and future milestones have been moved to a dedicated document. 

--- a/docs/UNIVERSAL_STRATEGY.md
+++ b/docs/UNIVERSAL_STRATEGY.md
@@ -1,0 +1,40 @@
+# The Universal Remastering Strategy
+
+One of the greatest challenges in Linux remastering is fragmentation. Every distribution family (Debian, RedHat, Arch, SUSE) handles the boot process, kernel initialization, and user identities differently. Traditional remastering tools fail or require complex, fragile `if/else` bash scripts to adapt to each environment.
+
+**oa** solves this by abstracting the host operating system entirely, relying on four foundational pillars:
+
+## 1. The "Debian Passepartout" Bootloader
+Instead of fighting with the specific GRUB patches of RedHat, the quirks of Manjaro, or the minimalist setup of Arch Linux, **oa** uses a "passkey" approach for the ISO boot process.
+
+* **The Method**: Through the `bootloaders_path` JSON parameter, the engine can be instructed to use an external, pre-compiled set of reliable bootloaders (extracted from Debian) provided by the orchestrator.
+* **The Execution**: `oa` injects `isolinux.bin`, its `.c32` modules, and the monolithic `grubx64.efi` directly into the ISO structure. 
+* **The Result**: The host distribution's internal bootloader configuration is completely bypassed for the Live environment. The ISO boots using the battle-tested Debian EFI/BIOS payload, which then safely passes the execution to the host's kernel and initrd.
+
+## 2. Yocto-Style Native Identity Forging
+Host binaries like `useradd`, `groupadd`, or `chpasswd` behave differently across distributions and relying on them inside a `chroot` during remastering is dangerous and error-prone.
+
+* **The Method**: Inspired by OpenEmbedded-Core (Yocto), **oa** ignores the host tools entirely.
+* **The Execution**: The engine operates purely at the C stream level. It opens `/etc/passwd`, `/etc/shadow`, and `/etc/group` natively. It sanitizes host identities by strictly filtering POSIX UIDs/GIDs. Then, it handcrafts the new `live` user and injects it into the necessary secondary groups using standard C string manipulation.
+* **The Result**: Total independence from the host's PAM configuration or shadow-utils package.
+
+## 3. The Initramfs Abstraction
+The Initial RAM Disk is the crucial trigger that boots the system, but its generation tool varies wildly (`initramfs-tools` on Debian, `dracut` on Fedora/SUSE, `mkinitcpio` on Arch).
+
+* **The Method**: **oa** delegates the knowledge of *how* to generate the initramfs to the upper-level orchestrator via the JSON plan.
+* **The Execution**: The orchestrator simply passes a template string (e.g., `"initrd_cmd": "dracut --nomadas --force {{out}} {{ver}}"`). `oa` resolves the host kernel version dynamically, replaces the `{{out}}` and `{{ver}}` placeholders, and executes the command within the `liveroot` chroot.
+* **The Result**: The C engine remains tiny and completely agnostic, while flawlessly triggering the correct ramdisk generation for any Linux family.
+
+## 4. The Role of the Orchestrator (The Mind)
+While **oa** provides the raw, native power to execute complex system tasks in milliseconds, it is intentionally designed as an unopinionated engine. It only knows *how* to execute a task, not *what* or *when* to execute it.
+
+This is where the high-level **Orchestrator** (such as *penguins-eggs*, written in TypeScript) steps in. The Orchestrator acts as the "Mind" of the operation:
+* **System Analysis**: It detects the host distribution and gathers necessary environment variables.
+* **User Interaction**: It collects the user's intent (e.g., standard ISO, encrypted clone, specific desktop environments).
+* **Plan Generation**: Based on these inputs, the Orchestrator dynamically compiles the `plan.json` file. It determines the correct `bootloaders_path`, formulates the precise `initrd_cmd`, and structures the workflow.
+* **Execution**: Finally, it hands the custom-generated plan over to **oa** for the heavy lifting.
+
+This strict separation of concerns—a high-level Orchestrator for complex logic and a minimalist C engine for kernel-level execution—makes the ecosystem extremely secure and adaptable.
+
+## Conclusion: Breaking the Distro Barrier
+By combining the **Debian Bootloader Payload**, **Yocto-style Native Identity Management**, **Initramfs Abstraction**, and a **Dynamic Orchestrator**, `oa` achieves true distro-agnosticism. The host system is treated merely as a pool of passive files (projected via OverlayFS). The critical phases—booting the ISO, initializing the kernel, and logging in the live user—are completely managed, allowing flawless remastering of Arch, RHEL, OpenSUSE, Manjaro, and Debian families using the exact same compiled core.

--- a/json/plan-clone.json
+++ b/json/plan-clone.json
@@ -2,6 +2,7 @@
   "pathLiveFs": "/home/eggs",
   "mode": "clone",
   "initrd_cmd": "mkinitramfs -o {{out}} {{ver}}",
+  "bootloaders_path": "",
   "plan": [
     {
       "command": "action_prepare"

--- a/json/plan-crypted.json
+++ b/json/plan-crypted.json
@@ -2,6 +2,7 @@
   "pathLiveFs": "/home/eggs",
   "mode": "crypted",
   "initrd_cmd": "mkinitramfs -d /home/eggs/liveroot/etc/initramfs-tools -o {{out}} {{ver}}",
+  "bootloaders_path": "",
   "plan": [
     {
       "command": "action_prepare"

--- a/json/plan-standard.json
+++ b/json/plan-standard.json
@@ -2,6 +2,7 @@
   "pathLiveFs": "/home/eggs",
   "mode": "standard",
   "initrd_cmd": "mkinitramfs -o {{out}} {{ver}}",
+  "bootloaders_path": "",
   "users": [
     {
       "login": "live",
@@ -41,11 +42,6 @@
     {
       "command": "action_uefi"
     },
-    {
-      "command": "action_suspend",
-      "message": "open another terminal to check chroot"
-    },
-    
     {
       "command": "action_squash"
     },

--- a/src/actions/action_iso.c
+++ b/src/actions/action_iso.c
@@ -8,7 +8,7 @@
 #include "oa.h"
 
 /**
- * @brief Finalizza la ISO avviabile usando il contesto globale/locale
+ * @brief Finalizza la ISO avviabile (BIOS + UEFI) usando il contesto globale/locale
  */
 int action_iso(OA_Context *ctx) {
     // 1. Lookup Strategico: Locale (task) > Globale (root)
@@ -21,6 +21,9 @@ int action_iso(OA_Context *ctx) {
     cJSON *output_iso = cJSON_GetObjectItemCaseSensitive(ctx->task, "output_iso");
     if (!output_iso) output_iso = cJSON_GetObjectItemCaseSensitive(ctx->root, "output_iso");
 
+    cJSON *bootloaders_path = cJSON_GetObjectItemCaseSensitive(ctx->task, "bootloaders_path");
+    if (!bootloaders_path) bootloaders_path = cJSON_GetObjectItemCaseSensitive(ctx->root, "bootloaders_path");
+
     if (!cJSON_IsString(pathLiveFs)) {
         fprintf(stderr, "{\"error\": \"pathLiveFs mancante nel contesto ISO\"}\n");
         return 1;
@@ -28,29 +31,68 @@ int action_iso(OA_Context *ctx) {
 
     char iso_root[PATH_SAFE], output_iso_path[PATH_SAFE];
     
-    // Definiamo la sorgente (cartella iso)
+    // Definiamo la sorgente (cartella iso) e la destinazione (file .iso)
     snprintf(iso_root, sizeof(iso_root), "%s/iso", pathLiveFs->valuestring);
-
-    // Definiamo la destinazione (file .iso)
     snprintf(output_iso_path, sizeof(output_iso_path), "%s/%s", 
              pathLiveFs->valuestring, 
              cJSON_IsString(output_iso) ? output_iso->valuestring : "live-system.iso");
 
-    // Usiamo CMD_MAX (32K) per il comando xorriso
+    // 2. Risoluzione percorso isohdpfx.bin (MBR ibrido)
+    char isohdpfx_src[PATH_SAFE];
+    if (cJSON_IsString(bootloaders_path) && strlen(bootloaders_path->valuestring) > 0) {
+        snprintf(isohdpfx_src, PATH_SAFE, "%s/isohdpfx.bin", bootloaders_path->valuestring);
+    } else {
+        strncpy(isohdpfx_src, "/usr/lib/ISOLINUX/isohdpfx.bin", PATH_SAFE);
+    }
+
     char cmd[CMD_MAX];
+    char uefi_args[1024] = "";
+    char efi_check[PATH_SAFE];
+    snprintf(efi_check, sizeof(efi_check), "%s/EFI", iso_root);
+
+    // 3. Creazione dinamica di efi.img se è stato preparato l'ambiente UEFI
+    if (access(efi_check, F_OK) == 0) {
+        printf("\033[1;34m[oa ISO Mode]\033[0m Generating FAT efi.img for UEFI hybrid boot...\n");
+        char efi_img_path[PATH_SAFE];
+        snprintf(efi_img_path, PATH_SAFE, "%s/boot/grub/efi.img", iso_root);
+
+        // Alloca 4MB, formatta in FAT, monta in loop, copia la cartella EFI e smonta
+        snprintf(cmd, sizeof(cmd),
+            "dd if=/dev/zero of=%s bs=1M count=4 status=none && "
+            "mkfs.vfat %s >/dev/null && "
+            "mkdir -p /tmp/oa_efi_mnt && "
+            "mount -o loop %s /tmp/oa_efi_mnt && "
+            "cp -r %s/EFI /tmp/oa_efi_mnt/ && "
+            "umount /tmp/oa_efi_mnt && "
+            "rmdir /tmp/oa_efi_mnt",
+            efi_img_path, efi_img_path, efi_img_path, iso_root);
+
+        if (system(cmd) == 0) {
+            snprintf(uefi_args, sizeof(uefi_args), 
+                     "-eltorito-alt-boot -e boot/grub/efi.img -no-emul-boot -isohybrid-gpt-basdat ");
+            LOG_INFO("Successfully generated efi.img for UEFI support.");
+        } else {
+            LOG_ERR("Failed to generate efi.img! ISO will be BIOS-only.");
+        }
+    }
+
+    // 4. Assemblaggio finale comando xorriso
     snprintf(cmd, sizeof(cmd),
              "xorriso -as mkisofs -J -joliet-long -r -l -iso-level 3 "
-             "-isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin "
+             "-isohybrid-mbr %s "
              "-partition_offset 16 -V '%s' "
              "-b isolinux/isolinux.bin -c isolinux/boot.cat "
              "-no-emul-boot -boot-load-size 4 -boot-info-table "
+             "%s" // Iniezione argomenti UEFI (se efi.img è stato creato)
              "-o %s %s/",
+             isohdpfx_src,
              cJSON_IsString(volid) ? volid->valuestring : "OA_LIVE",
+             uefi_args,
              output_iso_path, 
              iso_root);
 
-    printf("\n\033[1;32m[oa ISO Mode]\033[0m Finalizing ISO: %s\n", 
+    printf("\n\033[1;32m[oa ISO Mode]\033[0m Finalizing Hybrid ISO: %s\n", 
            cJSON_IsString(output_iso) ? output_iso->valuestring : "live-system.iso");
-
+           
     return system(cmd);
 }

--- a/src/actions/action_isolinux.c
+++ b/src/actions/action_isolinux.c
@@ -11,6 +11,9 @@ int action_isolinux(OA_Context *ctx) {
     if (!pathLiveFs) pathLiveFs = cJSON_GetObjectItemCaseSensitive(ctx->root, "pathLiveFs");
     if (!cJSON_IsString(pathLiveFs)) return 1;
 
+    cJSON *bootloaders_path = cJSON_GetObjectItemCaseSensitive(ctx->task, "bootloaders_path");
+    if (!bootloaders_path) bootloaders_path = cJSON_GetObjectItemCaseSensitive(ctx->root, "bootloaders_path");
+
     char isolinux_dir[PATH_SAFE];
     snprintf(isolinux_dir, PATH_SAFE, "%s/iso/isolinux", pathLiveFs->valuestring);
 
@@ -19,14 +22,23 @@ int action_isolinux(OA_Context *ctx) {
     system(cmd);
 
     printf("\033[1;34m[oa ISOLINUX]\033[0m Populating BIOS bootloader binaries...\n");
-    snprintf(cmd, sizeof(cmd), "cp /usr/lib/ISOLINUX/isolinux.bin %s/ && "
-                               "cp /usr/lib/syslinux/modules/bios/*.c32 %s/", 
-             isolinux_dir, isolinux_dir);
+
+    // 1. Logica di copia dinamica
+    if (cJSON_IsString(bootloaders_path) && strlen(bootloaders_path->valuestring) > 0) {
+        snprintf(cmd, sizeof(cmd), "cp %s/isolinux.bin %s/ && cp %s/*.c32 %s/ 2>/dev/null || true", 
+                 bootloaders_path->valuestring, isolinux_dir,
+                 bootloaders_path->valuestring, isolinux_dir);
+        printf("\033[1;34m[oa ISOLINUX]\033[0m Using external binaries from: %s\n", bootloaders_path->valuestring);
+    } else {
+        snprintf(cmd, sizeof(cmd), "cp /usr/lib/ISOLINUX/isolinux.bin %s/ && cp /usr/lib/syslinux/modules/bios/*.c32 %s/", 
+                 isolinux_dir, isolinux_dir);
+    }
     system(cmd);
 
-    // Configurazione Isolinux
+    // 2. Configurazione Isolinux di default
     char cfg_path[PATH_SAFE];
     snprintf(cfg_path, PATH_SAFE, "%s/isolinux.cfg", isolinux_dir);
+
     if (access(cfg_path, F_OK) != 0) {
         FILE *f = fopen(cfg_path, "w");
         if (f) {

--- a/src/actions/action_uefi.c
+++ b/src/actions/action_uefi.c
@@ -11,17 +11,93 @@ int action_uefi(OA_Context *ctx) {
     if (!pathLiveFs) pathLiveFs = cJSON_GetObjectItemCaseSensitive(ctx->root, "pathLiveFs");
     if (!cJSON_IsString(pathLiveFs)) return 1;
 
-    char efi_dir[PATH_SAFE], grub_dir[PATH_SAFE];
+    // Estrazione parametro custom per i bootloaders (opzionale)
+    cJSON *bootloaders_path = cJSON_GetObjectItemCaseSensitive(ctx->task, "bootloaders_path");
+    if (!bootloaders_path) bootloaders_path = cJSON_GetObjectItemCaseSensitive(ctx->root, "bootloaders_path");
+
+    char efi_dir[PATH_SAFE], grub_dir[PATH_SAFE], grub_cfg_dir[PATH_SAFE];
     snprintf(efi_dir, PATH_SAFE, "%s/iso/EFI/BOOT", pathLiveFs->valuestring);
-    snprintf(grub_dir, PATH_SAFE, "%s/iso/boot/grub", pathLiveFs->valuestring);
+    snprintf(grub_dir, PATH_SAFE, "%s/iso/boot/grub/x86_64-efi", pathLiveFs->valuestring);
+    snprintf(grub_cfg_dir, PATH_SAFE, "%s/iso/boot/grub", pathLiveFs->valuestring);
 
     char cmd[CMD_MAX];
     snprintf(cmd, sizeof(cmd), "mkdir -p %s %s", efi_dir, grub_dir);
     system(cmd);
 
     printf("\033[1;34m[oa UEFI]\033[0m Preparing UEFI boot directories...\n");
-    
-    // TODO: Aggiungere l'estrazione di grubx64.efi, bootx64.efi e la generazione di grub.cfg
+
+    char efi_src[PATH_SAFE] = "";
+    char grub_mods_src[PATH_SAFE] = "";
+
+    // 1. Logica di selezione della sorgente
+    if (cJSON_IsString(bootloaders_path) && strlen(bootloaders_path->valuestring) > 0) {
+        snprintf(efi_src, PATH_SAFE, "%s/grubx64.efi", bootloaders_path->valuestring);
+        snprintf(grub_mods_src, PATH_SAFE, "%s/x86_64-efi", bootloaders_path->valuestring);
+        printf("\033[1;34m[oa UEFI]\033[0m Using external bootloaders from: %s\n", bootloaders_path->valuestring);
+    } else {
+        // Fallback standard host Debian
+        if (access("/usr/lib/grub/x86_64-efi/monolithic/grubx64.efi", F_OK) == 0) {
+            strncpy(efi_src, "/usr/lib/grub/x86_64-efi/monolithic/grubx64.efi", PATH_SAFE);
+        } else if (access("/boot/efi/EFI/debian/grubx64.efi", F_OK) == 0) {
+            strncpy(efi_src, "/boot/efi/EFI/debian/grubx64.efi", PATH_SAFE);
+        }
+        strncpy(grub_mods_src, "/usr/lib/grub/x86_64-efi", PATH_SAFE);
+    }
+
+    // 2. Copia del payload EFI (bootx64.efi)
+    if (strlen(efi_src) > 0) {
+        snprintf(cmd, sizeof(cmd), "cp %s %s/bootx64.efi", efi_src, efi_dir);
+        system(cmd);
+        LOG_INFO("Extracted UEFI bootloader from %s", efi_src);
+    } else {
+        LOG_WARN("No EFI payload found. UEFI boot might fail.");
+        printf("\033[1;33m[oa UEFI]\033[0m Warning: No EFI payload found.\n");
+    }
+
+    // 3. Copia dei moduli GRUB (*.mod, *.lst, ecc.)
+    if (access(grub_mods_src, F_OK) == 0) {
+        snprintf(cmd, sizeof(cmd), "cp -r %s/* %s/ 2>/dev/null || true", grub_mods_src, grub_dir);
+        system(cmd);
+        LOG_INFO("Extracted GRUB modules from %s", grub_mods_src);
+    } else {
+        LOG_WARN("GRUB modules not found at %s", grub_mods_src);
+    }
+
+    // 4. Generazione automatica di grub.cfg (MENU PRINCIPALE)
+    char cfg_path[PATH_SAFE];
+    snprintf(cfg_path, PATH_SAFE, "%s/grub.cfg", grub_cfg_dir);
+
+    FILE *f = fopen(cfg_path, "w");
+    if (f) {
+        fprintf(f, 
+            "search --no-floppy --set=root --file /live/vmlinuz\n\n"
+            "set default=\"0\"\n"
+            "set timeout=10\n\n"
+            "menuentry \"oa Live System (UEFI)\" {\n"
+            "    echo \"Loading kernel...\"\n"
+            "    linux /live/vmlinuz boot=live components quiet splash\n"
+            "    echo \"Loading initial ramdisk...\"\n"
+            "    initrd /live/initrd.img\n"
+            "}\n"
+        );
+        fclose(f);
+        printf("\033[1;32m[oa UEFI]\033[0m Main grub.cfg generated.\n");
+    }
+
+    // 5. Generazione del grub.cfg TRAMPOLINO (nella partizione FAT EFI)
+    char efi_cfg_path[PATH_SAFE];
+    snprintf(efi_cfg_path, PATH_SAFE, "%s/grub.cfg", efi_dir);
+
+    FILE *f_efi = fopen(efi_cfg_path, "w");
+    if (f_efi) {
+        fprintf(f_efi, 
+            "search --no-floppy --set=root --file /boot/grub/grub.cfg\n"
+            "set prefix=($root)/boot/grub\n"
+            "configfile /boot/grub/grub.cfg\n"
+        );
+        fclose(f_efi);
+        printf("\033[1;32m[oa UEFI]\033[0m EFI trampoline grub.cfg generated.\n");
+    }
 
     return 0;
 }


### PR DESCRIPTION
## [Unreleased] - 2026-04-02

### 🚀 Added
- **Agnostic Bootloader Injection**: Introduced the `bootloaders_path` JSON parameter. `action_uefi` and `action_isolinux` can now dynamically pull bootloader binaries (like Debian's `grubx64.efi` and `isolinux.bin`) from an external path provided by the orchestrator, enabling universal booting for non-Debian host systems.
- **Hybrid UEFI/BIOS ISO Master**: `action_iso` now automatically detects the presence of UEFI payloads and dynamically generates a 4MB FAT `efi.img` (via `dd`, `mkfs.vfat`, and loop mount) to inject into `xorriso` using the `-eltorito-alt-boot` flag.
- **UEFI Trampoline Configuration**: Added a secondary `grub.cfg` inside the `EFI/BOOT/` directory to act as a trampoline. This redirects the firmware to the main `/boot/grub/grub.cfg` on the ISO9660 filesystem, completely avoiding the dreaded `grub rescue>` prompt.

### 🛠 Changed
- **Plan JSONs Updated**: All JSON templates (`plan-standard.json`, `plan-clone.json`, `plan-crypted.json`) have been updated to include the `bootloaders_path` key and the correct modern modular actions.
- **Code Refactoring**: Removed the legacy monolithic `action_remaster` logic completely, distributing its responsibilities natively into `action_livestruct`, `action_isolinux`, and `action_uefi`.

### 🐛 Fixed
- **Missing GRUB Modules**: Fixed an issue in `action_uefi` where `*.mod` and `*.lst` files were not copied to the `x86_64-efi` directory, causing boot failures.

### 📚 Documented
- **Universal Strategy Manifesto**: Created `docs/UNIVERSAL_STRATEGY.md` outlining the 4 pillars of the *penguins-eggs* ecosystem (Debian Passepartout, Yocto-style identity, Initramfs abstraction, and the Orchestrator role).
- **Architecture Guide Update**: Added details about the `tmpfs` Anti-Inception shield and dynamic `/home` handling to `docs/ARCHITECTURE.md`.
- **Actions Reference**: Completely overhauled `docs/ACTIONS.md` to reflect the new C engine modules (added `cleanup`, `crypted`, `scan`, `suspend`).
- **README and Roadmap**: Cleaned up `README.md`, moved future goals to a dedicated `docs/ROADMAP.md`, and added links to the philosophical architecture.