### PR TITLE
Devel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 # Changelog - oa-tools
 
-# Changelog - oa (Artisan's Dialect of Eggs)
+## [0.7.2] - 2026-05-01
+
+### **Core Improvements & Fixes**
+*   **Standardized Sudo Privileges**: Implemented a unified "Arch-style" sudo configuration for the live user, ensuring seamless operation of **oa** tools across Arch, Debian, and Manjaro bases.
+*   **Enhanced Build Cleanup**: Integrated a "tabula rasa" policy during the remastering process to automatically remove legacy or malformed configuration files (e.g., `00_artisan`) that previously caused syntax errors in the sudoers directory.
+*   **Post-Installation Optimization**: Added an automated cleanup routine to the **FINALIZE** stage. This ensures that the installed system is stripped of live-environment "ghost" files, leaving only the necessary installer-generated permissions.
+*   **Permission Hardening**: Enforced strict `0440` permissions for generated sudoers files to comply with security standards and prevent them from being ignored by the system.
+
+---
+
+This release marks a significant step in the **eggs-bananas** philosophy, delivering a cleaner, more professional transition from the live environment to the final installation.
+
+
 ## [0.7.1] - 2026-04-30
 ### "The Streamlined Artisan" Update
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,38 @@
+# Building oa-tools: Requirements & Toolchain
+
+To generate native packages for **oa-tools** (Debian `.deb`, Arch/Manjaro `.pkg.tar.zst`, Fedora `.rpm`), your build environment must have the following tools installed. This setup follows the **"Eggs & Bananas"** philosophy of using essential, high-quality tools for maximum efficiency.
+
+## 1. Universal Core (The Artisan's Workshop)
+Regardless of the distribution, these are mandatory to compile the "Mind" (Go) and the "Arm" (C):
+*   **Go Compiler (1.20+)**: Required to compile the `coa` engine.
+*   **GCC & Make**: Required to compile the `oa` C engine.
+*   **Git**: Required for versioning and managing the `wardrobe`.
+
+## 2. Distribution-Specific Requirements
+
+### Arch Linux / Manjaro / BigLinux
+To use `build_arch.go` or `build_manjaro.go` and generate packages:
+*   **base-devel**: Essential build utilities (includes `makepkg` and `fakeroot`).
+*   **pacman-contrib**: Provides helpful tools for package maintenance.
+
+### Debian / Ubuntu
+To generate standard `.deb` packages:
+*   **build-essential**: The core compiler and toolchain.
+*   **devscripts & debhelper**: Required for standard Debian packaging workflows.
+
+### Fedora / Red Hat / Nobara
+To generate `.rpm` packages using the Fedora-agnostic logic:
+*   **fedora-packager**: Provides the essential infrastructure for RPM creation.
+*   **rpm-build**: The core engine for building RPM packages.
+*   **dnf-plugins-core**: Necessary for managing build dependencies and toolchains.
+
+---
+
+## The v0.7.1 Build Logic
+Starting from version **0.7.1**, the build process has been simplified and purified:
+
+1.  **Agnostic Detection**: The builder automatically identifies the host distribution using the system's `ID_LIKE` metadata.
+2.  **Dynamic Generation**: `coa` generates a tailored `PKGBUILD`, `spec` file, or `debian/` directory on the fly based on the detected environment.
+3.  **Zero-Footprint**: By removing `derivatives.yaml`, the system no longer requires external mapping files to recognize derivative distributions (like Nobara being recognized as Fedora).
+
+> **Note**: This "Artisan" approach ensures that as long as your system reports a supported lineage in `/etc/os-release`, the builder will know exactly how to "cut the cloth" for your specific distribution.

--- a/coa/brain.d/arch.yaml
+++ b/coa/brain.d/arch.yaml
@@ -173,7 +173,7 @@ remaster:
   - name: "coa-xorriso"
     description: "Masterizzazione ISO finale"
     command: "oa_shell"
-    run_command: "xorriso -as mkisofs -R -J -joliet-long -l -cache-inodes -V 'OA_LIVE' -isohybrid-mbr /tmp/coa/bootloaders/ISOLINUX/isohdpfx.bin -partition_offset 16 -A 'OA_LIVE' -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e EFI/BOOT/efi.img -no-emul-boot -isohybrid-gpt-basdat -o ${ISO_OUTPUT} /home/eggs/isodir"
+    run_command: "xorriso -as mkisofs -iso-level 3 -R -J -joliet-long -l -cache-inodes -V 'OA_LIVE' -isohybrid-mbr /tmp/coa/bootloaders/ISOLINUX/isohdpfx.bin -partition_offset 16 -A 'OA_LIVE' -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e EFI/BOOT/efi.img -no-emul-boot -isohybrid-gpt-basdat -o ${ISO_OUTPUT} /home/eggs/isodir"
 
   # ---------------------------------------------------------
   # 11. PULIZIA FINALE

--- a/coa/brain.d/arch.yaml
+++ b/coa/brain.d/arch.yaml
@@ -49,15 +49,6 @@ remaster:
     command: "oa_users"
 
   # ---------------------------------------------------------
-  # 04. PRIVILEGI SUDO
-  # ---------------------------------------------------------
-  - name: "coa-privileges"
-    description: "Abilitazione poteri sudo per il gruppo live"
-    command: "oa_shell"
-    run_command: "sh -c \"echo '%wheel ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/10-live-group && chmod 440 /etc/sudoers.d/10-live-group\""
-    chroot: true
-
-  # ---------------------------------------------------------
   # 05. GENERAZIONE INITRAMFS
   # ---------------------------------------------------------
   - name: "coa-initrd"

--- a/coa/brain.d/arch.yaml
+++ b/coa/brain.d/arch.yaml
@@ -49,6 +49,19 @@ remaster:
     command: "oa_users"
 
   # ---------------------------------------------------------
+  # 04. ENABLE SUDO USER LIVE
+  # ---------------------------------------------------------
+  - name: "coa-enable-live"
+    description: "Abilitazione poteri sudo per user live"
+    command: "oa_shell"
+    run_command: |
+      mkdir -p /etc/sudoers.d
+      rm -f /etc/sudoers.d/00*
+      echo "live ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/00-live
+      chmod 0440 /etc/sudoers.d/00-live
+    chroot: true
+
+  # ---------------------------------------------------------
   # 05. GENERAZIONE INITRAMFS
   # ---------------------------------------------------------
   - name: "coa-initrd"
@@ -184,6 +197,9 @@ install:
   - name: "finalize"
     description: "Generazione initramfs e configurazione GRUB"
     command: |
+      # rimuove user live
+      rm -f /etc/sudoers.d/00-live
+
       # Rigenera le immagini initramfs per tutti i kernel installati
       mkinitcpio -P
       

--- a/coa/brain.d/debian.yaml
+++ b/coa/brain.d/debian.yaml
@@ -50,15 +50,6 @@ remaster:
     # Nota: Go inietterà automaticamente l'oggetto "users" qui
 
   # ---------------------------------------------------------
-  # 04. CONFIGURAZIONE PRIVILEGI SUDO
-  # ---------------------------------------------------------
-  - name: "coa-privileges"
-    description: "Abilitazione poteri sudo per il gruppo live"
-    command: "oa_shell"
-    run_command: "sh -c \"echo '%sudo ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/10-live-group && chmod 440 /etc/sudoers.d/10-live-group\""
-    chroot: true
-
-  # ---------------------------------------------------------
   # 05. GENERAZIONE INITRAMFS (DEBIAN STYLE)
   # ---------------------------------------------------------
   - name: "coa-initrd"
@@ -158,7 +149,7 @@ remaster:
   - name: "coa-xorriso"
     description: "Creazione della ISO finale con xorriso"
     command: "oa_shell"
-    run_command: "xorriso -as mkisofs -J -joliet-long -r -l -cache-inodes -V 'OA_LIVE' -isohybrid-mbr /tmp/coa/bootloaders/ISOLINUX/isohdpfx.bin -partition_offset 16 -A 'OA_LIVE' -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e EFI/BOOT/efi.img -no-emul-boot -isohybrid-gpt-basdat -o ${ISO_OUTPUT} /home/eggs/isodir"
+    run_command: "xorriso -as mkisofs -iso-level 3 -R -J -joliet-long -l -cache-inodes -V 'OA_LIVE' -isohybrid-mbr /tmp/coa/bootloaders/ISOLINUX/isohdpfx.bin -partition_offset 16 -A 'OA_LIVE' -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e EFI/BOOT/efi.img -no-emul-boot -isohybrid-gpt-basdat -o ${ISO_OUTPUT} /home/eggs/isodir"
 
   # ---------------------------------------------------------
   # 10. PULIZIA FINALE E UMOUNT

--- a/coa/brain.d/debian.yaml
+++ b/coa/brain.d/debian.yaml
@@ -50,6 +50,20 @@ remaster:
     # Nota: Go inietterà automaticamente l'oggetto "users" qui
 
   # ---------------------------------------------------------
+  # 04. ENABLE SUDO USER LIVE
+  # ---------------------------------------------------------
+  - name: "coa-enable-live"
+    description: "Abilitazione poteri sudo per user live"
+    command: "oa_shell"
+    run_command: |
+      mkdir -p /etc/sudoers.d
+      rm -f /etc/sudoers.d/00*
+      echo "live ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/00-live
+      chmod 0440 /etc/sudoers.d/00-live
+    chroot: true
+
+
+  # ---------------------------------------------------------
   # 05. GENERAZIONE INITRAMFS (DEBIAN STYLE)
   # ---------------------------------------------------------
   - name: "coa-initrd"
@@ -167,8 +181,10 @@ install:
   # 01. FINALIZZAZIONE SISTEMA
   # ---------------------------------------------------------
   - name: "finalize"
-    description: "Configurazione bootloader e initramfs"
+    description: "Generazione initramfs e configurazione GRUB"
     command: |
+      # rimuove user live
+      rm -f /etc/sudoers.d/00-live
       update-initramfs -u
       grub-install --recheck /dev/sda
       update-grub

--- a/coa/brain.d/fedora.yaml
+++ b/coa/brain.d/fedora.yaml
@@ -8,10 +8,17 @@ remaster:
     description: "Gestione nativa identità (Purge & Inject stile Yocto)"
     command: "oa_users"
 
-  - name: "coa-privileges"
-    description: "Abilitazione poteri sudo per il gruppo wheel (Fedora standard)"
+  # ---------------------------------------------------------
+  # 04. ENABLE SUDO USER LIVE
+  # ---------------------------------------------------------
+  - name: "coa-enable-live"
+    description: "Abilitazione poteri sudo per user live"
     command: "oa_shell"
-    run_command: "sh -c \"echo '%wheel ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/10-live-group && chmod 440 /etc/sudoers.d/10-live-group\""
+    run_command: |
+      mkdir -p /etc/sudoers.d
+      rm -f /etc/sudoers.d/00*
+      echo "live ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/00-live
+      chmod 0440 /etc/sudoers.d/00-live
     chroot: true
 
   - name: "coa-initrd"

--- a/coa/brain.d/manjaro.yaml
+++ b/coa/brain.d/manjaro.yaml
@@ -50,15 +50,6 @@ remaster:
     # Nota: Go inietterà automaticamente l'oggetto "users" qui
 
   # ---------------------------------------------------------
-  # 04. CONFIGURAZIONE PRIVILEGI SUDO
-  # ---------------------------------------------------------
-  - name: "coa-privileges"
-    description: "Abilitazione poteri sudo per il gruppo live"
-    command: "oa_shell"
-    run_command: "sh -c \"echo '%sudo ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/10-live-group && chmod 440 /etc/sudoers.d/10-live-group\""
-    chroot: true
-
-  # ---------------------------------------------------------
   # 05. GENERAZIONE INITRAMFS (MANJARO/MISO STYLE)
   # ---------------------------------------------------------
   - name: "coa-initrd"
@@ -193,7 +184,7 @@ remaster:
   - name: "coa-xorriso"
     description: "Masterizzazione ISO finale"
     command: "oa_shell"
-    run_command: "xorriso -as mkisofs -R -V 'OA_LIVE' -isohybrid-mbr /tmp/coa/bootloaders/ISOLINUX/isohdpfx.bin -partition_offset 16 -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e EFI/BOOT/efi.img -no-emul-boot -isohybrid-gpt-basdat -o ${ISO_OUTPUT} /home/eggs/isodir"
+    run_command: "xorriso -as mkisofs -iso-level 3 -R -J -joliet-long -l -cache-inodes -V 'OA_LIVE' -isohybrid-mbr /tmp/coa/bootloaders/ISOLINUX/isohdpfx.bin -partition_offset 16 -A 'OA_LIVE' -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e EFI/BOOT/efi.img -no-emul-boot -isohybrid-gpt-basdat -o ${ISO_OUTPUT} /home/eggs/isodir"
 
   # ---------------------------------------------------------
   # 12. PULIZIA FINALE E UMOUNT

--- a/coa/brain.d/manjaro.yaml
+++ b/coa/brain.d/manjaro.yaml
@@ -50,6 +50,19 @@ remaster:
     # Nota: Go inietterà automaticamente l'oggetto "users" qui
 
   # ---------------------------------------------------------
+  # 04. ENABLE SUDO USER LIVE
+  # ---------------------------------------------------------
+  - name: "coa-enable-live"
+    description: "Abilitazione poteri sudo per user live"
+    command: "oa_shell"
+    run_command: |
+      mkdir -p /etc/sudoers.d
+      rm -f /etc/sudoers.d/00*
+      echo "live ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/00-live
+      chmod 0440 /etc/sudoers.d/00-live
+    chroot: true
+
+  # ---------------------------------------------------------
   # 05. GENERAZIONE INITRAMFS (MANJARO/MISO STYLE)
   # ---------------------------------------------------------
   - name: "coa-initrd"
@@ -205,6 +218,9 @@ install:
   - name: "finalize"
     description: "Generazione initramfs e configurazione GRUB"
     command: |
+      # rimuove user live
+      rm -f /etc/sudoers.d/00-live
+
       # Rigenera le immagini initramfs per tutti i kernel installati
       mkinitcpio -P
       

--- a/coa/pkg/assets/calamares_base/settings.conf
+++ b/coa/pkg/assets/calamares_base/settings.conf
@@ -33,6 +33,7 @@ sequence:
       - localecfg       # Applica la localizzazione (se supportato)
       - users           # Crea l'utente senza controlli password fastidiosi
       - shellprocess@oa_bootloader
+      - removeuser      # rimuove utente live
       - umount          # Smonta tutto a lavoro finito
   - show:
       - finished

--- a/coa/pkg/calamares/prepare-removeuser-conf copy.go
+++ b/coa/pkg/calamares/prepare-removeuser-conf copy.go
@@ -1,0 +1,32 @@
+package calamares
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func PrepareRemoveuserConf() error {
+	// 1. Identifichiamo l'utente da rimuovere
+	// Usiamo "live", che è il nostro standard per l'uovo
+	liveUser := "live"
+
+	// 2. Generiamo lo YAML specifico per il modulo removeuser
+	// Nota: Il modulo si aspetta semplicemente la chiave 'username'
+	config := fmt.Sprintf(`---
+# OA-Tools: Configurazione Rimozione Utente Live
+# Questo modulo assicura che l'utente '%s' non resti nel sistema installato
+
+username: %s
+`, liveUser, liveUser)
+
+	// 3. Definiamo il percorso.
+	targetPath := "/etc/calamares/modules/removeuser.conf"
+
+	err := os.MkdirAll(filepath.Dir(targetPath), 0755)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(targetPath, []byte(config), 0644)
+}

--- a/coa/pkg/calamares/prepare-user-conf.go
+++ b/coa/pkg/calamares/prepare-user-conf.go
@@ -8,40 +8,65 @@ import (
 )
 
 func PrepareUserConf() error {
-	// 1. Wishlist universale dei gruppi
-	wishlist := []string{"wheel", "sudo", "audio", "video", "storage", "plugdev", "netdev", "network", "lpadmin", "scanner", "users"}
+	// 1. Wishlist dei gruppi (standard Calamares)
+	// Usiamo il formato semplice (stringa) o quello esteso (oggetto)
+	wishlist := []string{"users", "wheel", "audio", "video", "storage", "network", "lp", "scanner"}
 
-	// 2. Leggiamo i gruppi reali del sistema live
+	// 2. Verifica dei gruppi esistenti nel sistema live
 	data, err := os.ReadFile("/etc/group")
 	if err != nil {
 		return err
 	}
 	content := string(data)
 
-	var validGroups []string
+	var yamlGroups string
 	for _, g := range wishlist {
 		if strings.Contains(content, g+":") {
-			validGroups = append(validGroups, g)
+			// Se il gruppo esiste, lo aggiungiamo
+			yamlGroups += fmt.Sprintf("    - %s\n", g)
 		}
 	}
 
-	// 3. Generiamo lo YAML "Libertario"
-	var yamlGroups string
-	for _, v := range validGroups {
-		yamlGroups += fmt.Sprintf("    - %s\n", v)
-	}
-
+	// 3. Generiamo lo YAML basato sul tuo template
 	config := fmt.Sprintf(`---
 # OA-Tools: Configurazione Universale Dinamica
+# Password: Approccio "Libertario" totale per Eggs & Bananas
+
 defaultGroups:
 %s
-checkPasswordQuality: false
-passwordCheckMethod: none
-minPasswordLength: 1
-allowReusePassword: true
+
+sudoersGroup:    wheel
+sudoersConfigureWithGroup: false
+
+# Disabilitiamo la rimozione dell'utente live qui se usiamo il modulo specifico
+# removeLiveUser: true 
+
+# --- IL FIX PER LE PASSWORD ---
+# Permettiamo esplicitamente password deboli e lo impostiamo come default
+allowWeakPasswords: true
+allowWeakPasswordsDefault: true
+
+passwordRequirements:
+    minLength: -1
+    maxLength: -1
+    libpwquality:
+        - minlen=0
+        - minclass=0
+        - dictcheck=0  # <--- DISATTIVA IL CONTROLLO DIZIONARIO
+        - usercheck=0  # Disattiva controllo basato sul nome utente
+
+# Configurazione User & Hostname
+user:
+  shell: /bin/bash
+  forbidden_names: [ root, nobody ]
+  home_permissions: "o700"
+
+hostname:
+  location: EtcFile
+  writeHostsFile: true
+  template: "oa-${product}"
 `, yamlGroups)
 
-	// 4. Scrittura del file nella sessione live
 	targetPath := "/etc/calamares/modules/users.conf"
 	os.MkdirAll(filepath.Dir(targetPath), 0755)
 

--- a/coa/pkg/cmd/sysinstall_calamares.go
+++ b/coa/pkg/cmd/sysinstall_calamares.go
@@ -52,6 +52,10 @@ func RunCalamaresInstaller() {
 		utils.LogError("Errore configurazione utenti: %v", err)
 		// Non blocchiamo tutto, proviamo a procedere comunque
 	}
+	if err := calamares.PrepareRemoveuserConf(); err != nil {
+		utils.LogError("Errore creazione removeuser.conf: %v", err)
+		// Non blocchiamo tutto, proviamo a procedere comunque
+	}
 
 	// 5. LAUNCH: Calamares parte e trova la pappa pronta
 	if err := calamares.Launch(); err != nil {

--- a/coa/pkg/engine/generate_plan.go
+++ b/coa/pkg/engine/generate_plan.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"coa/pkg/pilot"
+	"coa/pkg/utils"
 )
 
 // GeneratePlan converte lo YAML in JSON. Ora accetta anche stopAfter!
@@ -55,6 +56,13 @@ func GeneratePlan(yamlSteps []pilot.YamlStep, familyID string, isRemaster bool, 
 				Info:       "Creazione home directory da /etc/skel",
 				RunCommand: "mkdir -p " + workPath + "/liveroot/home/live && cp -a " + workPath + "/liveroot/etc/skel/. " + workPath + "/liveroot/home/live/",
 			})
+
+			// Recuperiamo i gruppi "specchiati" dall'host (es. audio, video, docker, wheel)
+			mirroredGroups := utils.GetUserGroups()
+
+			// Iniettiamo i gruppi nell'utente di default prima di passarlo al piano
+			// In questo modo oa_users riceverà l'array JSON corretto
+			defaultUser.Groups = mirroredGroups
 
 			plan.Plan = append(plan.Plan, OATask{
 				Command:    "oa_users",

--- a/coa/pkg/utils/get_users_group.go
+++ b/coa/pkg/utils/get_users_group.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"os"
+	"os/user"
+)
+
+// GetUserGroups recupera i gruppi dell'utente che ha invocato sudo
+func GetUserGroups() []string {
+	// 1. Identifichiamo l'utente originale tramite la variabile SUDO_USER
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		// Se non siamo sotto sudo, restituiamo dei default sicuri
+		return []string{"wheel", "audio", "video", "storage", "network"}
+	}
+
+	u, err := user.Lookup(sudoUser)
+	if err != nil {
+		return []string{"wheel", "audio", "video", "storage"}
+	}
+
+	// 2. Recuperiamo tutti i GID dell'utente
+	gids, err := u.GroupIds()
+	if err != nil {
+		return []string{"wheel", "audio", "video"}
+	}
+
+	var groups []string
+	for _, gid := range gids {
+		g, err := user.LookupGroupId(gid)
+		if err == nil {
+			// Escludiamo il gruppo primario (spesso uguale allo username)
+			// per evitare conflitti durante la creazione dell'utente live
+			if g.Name != u.Username && g.Name != "users" {
+				groups = append(groups, g.Name)
+			}
+		}
+	}
+
+	// 3. Assicuriamoci che 'wheel' o 'sudo' siano presenti per i permessi
+	groups = append(groups, "wheel")
+
+	return groups
+}

--- a/oa/src/actions/oa-users.bak
+++ b/oa/src/actions/oa-users.bak
@@ -1,0 +1,114 @@
+#include "oa.h"
+#include "oa-users.h"
+#include "oa-yocto.h"
+#include <shadow.h>
+#include <crypt.h>
+#include <pwd.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+/**
+ * oa_users: Gestione delle identità nel nido.
+ * Implementa la logica di Purge (rimozione utenti host) e Inject (creazione utente live).
+ */
+int oa_users(OA_Context *ctx) {
+    // 1. Lookup dei percorsi e parametri
+    cJSON *pathLiveFs = cJSON_GetObjectItemCaseSensitive(ctx->task, "pathLiveFs");
+    if (!pathLiveFs) pathLiveFs = cJSON_GetObjectItemCaseSensitive(ctx->root, "pathLiveFs");
+    
+    cJSON *users = cJSON_GetObjectItemCaseSensitive(ctx->task, "users");
+    if (!users) users = cJSON_GetObjectItemCaseSensitive(ctx->root, "users");
+    
+    cJSON *mode_item = cJSON_GetObjectItemCaseSensitive(ctx->task, "mode");
+    const char *mode = cJSON_IsString(mode_item) ? mode_item->valuestring : "standard";
+
+    if (!cJSON_IsString(pathLiveFs)) {
+        LOG_ERR("oa_users: pathLiveFs mancante o non valido nel JSON");
+        return 1;
+    }
+
+    char liveroot[PATH_SAFE], p_path[PATH_SAFE], s_path[PATH_SAFE], g_path[PATH_SAFE];
+    snprintf(liveroot, sizeof(liveroot), "%s/liveroot", pathLiveFs->valuestring);
+    snprintf(p_path, sizeof(p_path), "%s/etc/passwd", liveroot);
+    snprintf(s_path, sizeof(s_path), "%s/etc/shadow", liveroot);
+    snprintf(g_path, sizeof(g_path), "%s/etc/group", liveroot);
+
+    LOG_INFO("Inizio gestione utenti in modalità: %s", mode);
+
+    // 2. PULIZIA (Sanitize): Rimuove gli utenti "umani" dell'host per lasciare il sistema pulito
+    if (strcmp(mode, "clone") != 0 && strcmp(mode, "crypted") != 0) {
+        LOG_INFO("Esecuzione sanitize identità host (modalità standard)...");
+        yocto_sanitize_file(p_path, OE_UID_HUMAN_MIN, OE_UID_HUMAN_MAX);
+        yocto_sanitize_shadow(s_path, p_path);
+        yocto_sanitize_file(g_path, OE_UID_HUMAN_MIN, OE_UID_HUMAN_MAX);
+    }
+
+    // 3. INIEZIONE NUOVE IDENTITÀ
+    if (cJSON_IsArray(users)) {
+        FILE *fp = fopen(p_path, "a");
+        FILE *fs = fopen(s_path, "a");
+        
+        if (!fp || !fs) { 
+            LOG_ERR("Errore fatale: impossibile aprire i database utenti in %s/etc/", liveroot);
+            if(fp) fclose(fp); 
+            if(fs) fclose(fs); 
+            return 1;
+        }
+
+        cJSON *u;
+        cJSON_ArrayForEach(u, users) {
+            const char *login = cJSON_GetObjectItemCaseSensitive(u, "login")->valuestring;
+            const char *pass  = cJSON_GetObjectItemCaseSensitive(u, "password")->valuestring;
+            const char *home  = cJSON_GetObjectItemCaseSensitive(u, "home")->valuestring;
+            
+            LOG_INFO("Creazione identità nativa: user='%s' home='%s' password:'%s'", login, home, pass);
+
+            // --- GESTIONE PASSWORD (Hashing) ---
+            // Se la password non è già un hash (inizia con $), la criptiamo in SHA-512
+            char *final_pass = (char *)pass;
+            if (pass && pass[0] != '$') {
+                // $6$ indica SHA-512, "oa" è il salt.
+                final_pass = crypt(pass, "$6$oa$");
+            }
+
+            // Scrittura nei database di sistema nativi
+            yocto_write_passwd(fp, login, OE_UID_HUMAN_MIN, OE_UID_HUMAN_MIN, "live,,,", home, "/bin/bash");
+            yocto_write_shadow(fs, login, final_pass);
+
+            // Aggiunta ai gruppi secondari (sudo, audio, video, ecc.)
+            cJSON *groups_obj = cJSON_GetObjectItemCaseSensitive(u, "groups");
+            if (cJSON_IsArray(groups_obj)) {
+                LOG_INFO("Aggiunta utente '%s' ai gruppi secondari...", login);
+                yocto_add_user_to_groups(g_path, login, groups_obj);
+            }
+
+            // 4. CONFIGURAZIONE HOME DIRECTORY
+            char full_home[PATH_SAFE];
+            snprintf(full_home, sizeof(full_home), "%s%s", liveroot, home);
+            
+            LOG_INFO("Popolamento home directory: %s", full_home);
+            if (mkdir(full_home, 0755) != 0 && errno != EEXIST) {
+                LOG_WARN("Attenzione: mkdir fallita per %s (errno: %d)", full_home, errno);
+            }
+
+            // Esecuzione skel + chroot tramite comando shell (atomico)
+            char home_cmd[CMD_MAX];
+            snprintf(home_cmd, sizeof(home_cmd), 
+                     "cp -a %s/etc/skel/. %s/ 2>/dev/null || true && chown -R %d:%d %s", 
+                     liveroot, full_home, OE_UID_HUMAN_MIN, OE_UID_HUMAN_MIN, full_home);
+            
+            if (system(home_cmd) == 0) {
+                LOG_INFO("Home di '%s' configurata con successo (skel+chown)", login);
+            } else {
+                LOG_ERR("Errore durante il comando di setup home per '%s'", login);
+            }
+        }
+        fclose(fp);
+        fclose(fs);
+    }
+    
+    LOG_INFO("Gestione utenti completata.");
+    return 0;
+}

--- a/oa/src/actions/oa-users.c
+++ b/oa/src/actions/oa-users.c
@@ -66,16 +66,24 @@ int oa_users(OA_Context *ctx) {
             LOG_INFO("Creazione identità nativa: user='%s' home='%s' password:'%s'", login, home, pass);
 
             // --- GESTIONE PASSWORD (Hashing) ---
-            // Se la password non è già un hash (inizia con $), la criptiamo in SHA-512
             char *final_pass = (char *)pass;
             if (pass && pass[0] != '$') {
-                // $6$ indica SHA-512, "oa" è il salt.
                 final_pass = crypt(pass, "$6$oa$");
             }
 
             // Scrittura nei database di sistema nativi
             yocto_write_passwd(fp, login, OE_UID_HUMAN_MIN, OE_UID_HUMAN_MIN, "live,,,", home, "/bin/bash");
             yocto_write_shadow(fs, login, final_pass);
+
+            // --- CREAZIONE GRUPPO PRIMARIO (Fix per Debian ID 1000) ---
+            FILE *fg = fopen(g_path, "a");
+            if (fg) {
+                fprintf(fg, "%s:x:%d:\n", login, OE_UID_HUMAN_MIN);
+                fclose(fg);
+                LOG_INFO("Gruppo primario '%s' (GID %d) creato con successo.", login, OE_UID_HUMAN_MIN);
+            } else {
+                LOG_ERR("Errore: impossibile aprire %s per creare il gruppo primario.", g_path);
+            }
 
             // Aggiunta ai gruppi secondari (sudo, audio, video, ecc.)
             cJSON *groups_obj = cJSON_GetObjectItemCaseSensitive(u, "groups");
@@ -93,7 +101,6 @@ int oa_users(OA_Context *ctx) {
                 LOG_WARN("Attenzione: mkdir fallita per %s (errno: %d)", full_home, errno);
             }
 
-            // Esecuzione skel + chroot tramite comando shell (atomico)
             char home_cmd[CMD_MAX];
             snprintf(home_cmd, sizeof(home_cmd), 
                      "cp -a %s/etc/skel/. %s/ 2>/dev/null || true && chown -R %d:%d %s", 


### PR DESCRIPTION
## [0.7.2] - 2026-05-01

### **Core Improvements & Fixes**
*   **Standardized Sudo Privileges**: Implemented a unified "Arch-style" sudo configuration for the live user, ensuring seamless operation of **oa** tools across Arch, Debian, and Manjaro bases.
*   **Enhanced Build Cleanup**: Integrated a "tabula rasa" policy during the remastering process to automatically remove legacy or malformed configuration files (e.g., `00_artisan`) that previously caused syntax errors in the sudoers directory.
*   **Post-Installation Optimization**: Added an automated cleanup routine to the **FINALIZE** stage. This ensures that the installed system is stripped of live-environment "ghost" files, leaving only the necessary installer-generated permissions.
*   **Permission Hardening**: Enforced strict `0440` permissions for generated sudoers files to comply with security standards and prevent them from being ignored by the system.

---

This release marks a significant step in the **eggs-bananas** philosophy, delivering a cleaner, more professional transition from the live environment to the final installation.
