### PR TITLE
Devel

### DIFF
--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -18,6 +18,13 @@ for link in vmlinuz initrd.img vmlinuz.old initrd.img.old; do
     [ -e "/$link" ] && cp -a "/$link" "$LIVEROOT/$link"
 done
 
+# 2.1. SIBLING: marker persistente del mode di remaster.
+# Vive fuori da installer.d (che viene rigenerato a ogni avvio
+# dell'installer) così BuildInstaller può leggerlo per sapere se gli
+# utenti sono già clonati da /home.
+mkdir -p "$LIVEROOT/etc/oa-tools.d"
+echo "mode: $MODE" > "$LIVEROOT/etc/oa-tools.d/sibling.yaml"
+
 # 3. BIND MOUNTS E SYMLINK (USRMERGE)
 for e in bin sbin lib lib64 opt root srv; do
     SRC="/$e"

--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -e
 
-# Argomenti: $1 = basepath (es. /home/eggs), $2 = isGitHubAction (true/false)
+# Argomenti: $1 = basepath (es. /home/eggs), $2 = isGitHubAction (true/false), $3 = mode (standard/clone/crypted)
 BASEPATH=$1
 GITHUB_ACTION=$2
+MODE=$3
 
 LIVEROOT="$BASEPATH/liveroot"
 OVERLAY="$BASEPATH/.overlay"
@@ -29,6 +30,17 @@ for e in bin sbin lib lib64 opt root srv; do
         mount --bind "$SRC" "$DST"
     fi
 done
+
+# 3.1. BIND MOUNT DI /home IN READ-ONLY (solo mode "clone" o "crypted")
+# Gli utenti NON vanno toccati: si clona la home reale così com'è invece di
+# iniettarne una nuova via skel. --make-slave evita che il bind si propaghi
+# sulla home host: LIVEROOT vive sotto $BASEPATH che è a sua volta dentro
+# /home, quindi un bind condiviso (default) qui genererebbe un mount-bomb.
+if [ "$MODE" = "clone" ] || [ "$MODE" = "crypted" ]; then
+    mkdir -p "$LIVEROOT/home"
+    mount --bind --make-slave /home "$LIVEROOT/home"
+    mount -o remount,bind,ro "$LIVEROOT/home"
+fi
 
 # 4. OVERLAY PER USR E VAR
 for ovlDir in usr var; do

--- a/coa/pkg/cmd/remaster.go
+++ b/coa/pkg/cmd/remaster.go
@@ -77,6 +77,7 @@ and generate a precise execution plan for the OA planner.`,
 			finalIsoPath,
 			stopAfter,
 			debugPlan, // <--- Passiamo il flag anche all'planner
+			produceMode,
 		)
 		if err != nil {
 			utils.Fatal("Impossibile generare il piano di volo: %v", err)

--- a/coa/pkg/planner/create-exclude-list.go
+++ b/coa/pkg/planner/create-exclude-list.go
@@ -28,6 +28,9 @@ func GenerateExcludeList(mode string, isGitHubAction bool) string {
 		"home/eggs/.overlay/.??*", // Questo prende i file nascosti ma ignora "." e ".."
 		"home/eggs/isodir/*",
 		"home/eggs/*.iso",
+		// In mode clone/crypted /home è bind-montata in liveroot: senza questa
+		// esclusione mksquashfs si rivede ricorsivamente sotto home/eggs/liveroot.
+		"home/eggs/liveroot",
 	)
 
 	// ==========================================================

--- a/coa/pkg/planner/generate-plan.go
+++ b/coa/pkg/planner/generate-plan.go
@@ -20,7 +20,8 @@ func GeneratePlan(
 	workPath string,
 	finalIsoPath string,
 	stopAfter string,
-	isDebug bool) (string, error) { // <--- Nuovo parametro
+	isDebug bool,
+	mode string) (string, error) { // <--- Nuovo parametro
 
 	var plan OAPlan
 
@@ -50,10 +51,17 @@ func GeneratePlan(
 
 		switch step.Module {
 		case "mount_logic":
-			plan.Plan = append(plan.Plan, mountLogic(workPath, isGitHubAction)...)
+			plan.Plan = append(plan.Plan, mountLogic(workPath, isGitHubAction, mode)...)
 
 		case "users":
-			plan.Plan = append(plan.Plan, oaUsers(plan.Settings, step, workPath)...)
+			// In modalità clone/crypted gli utenti reali arrivano già clonati
+			// tramite il bind mount di /home: il modulo "users" va saltato
+			// perché altrimenti sovrascriverebbe identità e password esistenti.
+			if mode == "clone" || mode == "crypted" {
+				utils.LogNormal("[ENGINE] Modalità '%s': utenti reali clonati da /home, salto il modulo 'users'.", mode)
+			} else {
+				plan.Plan = append(plan.Plan, oaUsers(plan.Settings, step, workPath)...)
+			}
 
 		case "umount":
 			plan.Plan = append(plan.Plan, OATask{

--- a/coa/pkg/planner/mount-logic.go
+++ b/coa/pkg/planner/mount-logic.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 )
 
-func mountLogic(basePath string, isGitHubAction bool) []OATask {
+func mountLogic(basePath string, isGitHubAction bool, mode string) []OATask {
 	// Puntiamo al nuovo script Bash "tuttofare"
 	scriptPath := "/etc/oa-tools.d/scripts/bootstrap-liveroot.sh"
-	cmd := fmt.Sprintf("%s %s %v", scriptPath, basePath, isGitHubAction)
+	cmd := fmt.Sprintf("%s %s %v %s", scriptPath, basePath, isGitHubAction, mode)
 
 	// Ritorna un singolo task moderno di tipo "shell"
 	return []OATask{

--- a/coa/pkg/sysinstall/setup/orchestrator.go
+++ b/coa/pkg/sysinstall/setup/orchestrator.go
@@ -1,6 +1,8 @@
 package setup
 
 import (
+	"path/filepath"
+
 	"coa/pkg/distro"
 	"coa/pkg/utils"
 )
@@ -10,6 +12,16 @@ func BuildInstaller(oaVersion string) error {
 	// 1. Inizializza il workspace
 	if err := initWorkspace(); err != nil {
 		return err
+	}
+
+	// 1.1. Se il sistema è stato remasterizzato in clone/crypted, gli
+	// utenti sono già clonati da /home: togliamo "users" dalla sequence
+	// condivisa prima che Calamares o Krill la leggano.
+	if mode := readSibling().Mode; mode == "clone" || mode == "crypted" {
+		utils.LogNormal("[INSTALLER] Modalità '%s': utenti già clonati, rimuovo lo step 'users' da settings.conf.", mode)
+		if err := stripUsersModule(filepath.Join(InstallerDRoot, "settings.conf")); err != nil {
+			return err
+		}
 	}
 
 	d := distro.NewDistro()

--- a/coa/pkg/sysinstall/setup/sibling.go
+++ b/coa/pkg/sysinstall/setup/sibling.go
@@ -1,0 +1,56 @@
+package setup
+
+import (
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// siblingPath è scritto dal remaster (bootstrap-liveroot.sh) e vive fuori
+// da InstallerDRoot, che BuildInstaller rigenera da zero ad ogni avvio
+// dell'installer: è l'unico stato che sopravvive a quel wipe.
+const siblingPath = "/etc/oa-tools.d/sibling.yaml"
+
+// Sibling rispecchia sibling.yaml. Per ora registra solo il mode di
+// remaster (standard/clone/crypted); in futuro potrà crescere.
+type Sibling struct {
+	Mode string `yaml:"mode"`
+}
+
+// readSibling legge il marker; "standard" se assente (es. sistema non
+// remasterizzato, ambiente di sviluppo).
+func readSibling() Sibling {
+	data, err := os.ReadFile(siblingPath)
+	if err != nil {
+		return Sibling{Mode: "standard"}
+	}
+
+	var s Sibling
+	if err := yaml.Unmarshal(data, &s); err != nil || s.Mode == "" {
+		return Sibling{Mode: "standard"}
+	}
+	return s
+}
+
+// stripUsersModule rimuove lo step "users" dalla sequence di settings.conf:
+// in mode clone/crypted gli utenti arrivano già clonati da /home, e
+// Calamares/Krill (che condividono la stessa sequence) non devono più
+// chiederli. Modifica testuale per non perdere i commenti del file.
+func stripUsersModule(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "- users" {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(filtered, "\n")), 0644)
+}

--- a/oa/src/native.c
+++ b/oa/src/native.c
@@ -162,8 +162,11 @@ int run_native_umount(cJSON *task) {
     }
 
     // 3. Smontiamo i bind mount standard in liveroot
-    const char *bind_mounts[] = {"opt", "root", "srv"};
-    for (int i = 0; i < 3; i++) {
+    // "home" è incluso per sicurezza: se in modalità clone/crypted è stato
+    // bind-montato, va smontato qui; se non lo è, umount2 fallisce in
+    // silenzio come per gli altri path, senza effetti collaterali.
+    const char *bind_mounts[] = {"opt", "root", "srv", "home"};
+    for (int i = 0; i < 4; i++) {
         snprintf(path, sizeof(path), "%s/liveroot/%s", work_dir, bind_mounts[i]);
         umount2(path, MNT_DETACH);
     }


### PR DESCRIPTION
wired up the --mode=clone flag, resulting in the inclusion of ALL users and ALL user data in plaintext.