### PR TITLE
tailor: support nested sequence/finalize schema in costume YAML

### DIFF
--- a/coa/pkg/tailor/repositories.go
+++ b/coa/pkg/tailor/repositories.go
@@ -1,0 +1,101 @@
+package tailor
+
+import (
+	"coa/pkg/utils"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// setupRepositories applica la sezione "repositories" della forma annidata:
+// abilita i componenti richiesti (main, contrib, non-free...), esegue i
+// comandi letterali di sources_list_d (aggiunta repo di terze parti) e
+// lancia update/upgrade se richiesti.
+func setupRepositories(repos *Repositories, suitName string) {
+	if repos == nil {
+		return
+	}
+
+	if len(repos.SourcesList) > 0 {
+		if err := enableAptComponents(repos.SourcesList); err != nil {
+			logToFile(WarnPrefix(suitName) + "sources.list: " + err.Error())
+		}
+	}
+
+	if len(repos.SourcesListD) > 0 {
+		logToFile(WarnPrefix(suitName) + "running third-party repository setup commands...")
+		for _, command := range repos.SourcesListD {
+			if err := utils.Exec(command); err != nil {
+				logToFile(WarnPrefix(suitName) + "repository command failed: " + command + ": " + err.Error())
+			}
+		}
+	}
+
+	if repos.Update {
+		logToFile(WarnPrefix(suitName) + "apt-get update...")
+		utils.Exec("apt-get update")
+	}
+
+	if repos.Upgrade {
+		logToFile(WarnPrefix(suitName) + "apt-get upgrade...")
+		utils.Exec("DEBIAN_FRONTEND=noninteractive apt-get upgrade -y")
+	}
+}
+
+// WarnPrefix genera un prefisso omogeneo per i log di questo pacchetto.
+func WarnPrefix(suitName string) string {
+	return "[" + suitName + "] "
+}
+
+// enableAptComponents assicura che i componenti richiesti (contrib, non-free,
+// non-free-firmware...) siano abilitati sulle righe "deb" del sources.list
+// classico. Formato deb822 (/etc/apt/sources.list.d/*.sources) non e'
+// gestito qui: viene lasciato intatto e segnalato nel log.
+func enableAptComponents(components []string) error {
+	const path = "/etc/apt/sources.list"
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	debLineRe := regexp.MustCompile(`^(deb|deb-src)\s+(\S+)\s+(\S+)\s+(.*)$`)
+
+	lines := strings.Split(string(data), "\n")
+	changed := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		m := debLineRe.FindStringSubmatch(trimmed)
+		if m == nil {
+			continue
+		}
+		existing := strings.Fields(m[4])
+		existingSet := make(map[string]struct{}, len(existing))
+		for _, c := range existing {
+			existingSet[c] = struct{}{}
+		}
+
+		added := false
+		for _, want := range components {
+			if _, ok := existingSet[want]; !ok {
+				existing = append(existing, want)
+				existingSet[want] = struct{}{}
+				added = true
+			}
+		}
+
+		if added {
+			lines[i] = strings.Join([]string{m[1], m[2], m[3], strings.Join(existing, " ")}, " ")
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
+}

--- a/coa/pkg/tailor/types.go
+++ b/coa/pkg/tailor/types.go
@@ -12,8 +12,56 @@ type WardrobeInfo struct {
 type Suit struct {
 	Name        string           `yaml:"name"`
 	Description string           `yaml:"description"`
-	Packages    []string         `yaml:"packages"`    // Pacchetti di riferimento (Debian)
-	Accessories []string         `yaml:"accessories"` // Altri vestiti inclusi
-	Cmds        []string         `yaml:"cmds"`        // Comandi post-install
+	Packages    []string         `yaml:"packages"`    // Pacchetti di riferimento (Debian) - forma piatta (legacy)
+	Accessories []string         `yaml:"accessories"` // Altri vestiti inclusi - forma piatta (legacy)
+	Cmds        []string         `yaml:"cmds"`        // Comandi post-install - forma piatta (legacy)
 	Dress       []planner.OATask `yaml:"dress"`       // Task complessi opzionali
+
+	// Forma annidata, usata dalla maggior parte dei costume attuali
+	// (owl, duck, chicks, albatros, eagle, gypaetus, seagull...).
+	Distributions []string  `yaml:"distributions"`
+	Sequence      *Sequence `yaml:"sequence"`
+	Finalize      *Finalize `yaml:"finalize"`
+	Reboot        bool      `yaml:"reboot"`
+
+	// Popolato da normalize() a partire da Sequence.PackagesNoInstallRecommends.
+	PackagesNoRecommends []string `yaml:"-"`
+}
+
+// Sequence raccoglie repository, pacchetti e accessori nella forma annidata.
+type Sequence struct {
+	Repositories                *Repositories `yaml:"repositories"`
+	Packages                    []string      `yaml:"packages"`
+	PackagesNoInstallRecommends []string      `yaml:"packages_no_install_recommends"`
+	Accessories                 []string      `yaml:"accessories"`
+	Cmds                        []string      `yaml:"cmds"`
+}
+
+// Repositories descrive le modifiche alle sorgenti apt prima dell'installazione.
+type Repositories struct {
+	SourcesList   []string `yaml:"sources_list"`   // componenti da abilitare: main, contrib, non-free...
+	SourcesListD  []string `yaml:"sources_list_d"` // comandi shell letterali (aggiunta repo di terze parti)
+	Update        bool     `yaml:"update"`
+	Upgrade       bool     `yaml:"upgrade"`
+}
+
+// Finalize raccoglie i comandi eseguiti a fine costume nella forma annidata.
+type Finalize struct {
+	Customize bool     `yaml:"customize"`
+	Cmds      []string `yaml:"cmds"`
+}
+
+// normalize fonde i campi della forma annidata (Sequence/Finalize) in quelli
+// piatti (Packages/Accessories/Cmds) usati dal resto del pacchetto, cosi'
+// applySuit non deve conoscere la differenza tra le due forme.
+func (s *Suit) normalize() {
+	if s.Sequence != nil {
+		s.Packages = append(s.Packages, s.Sequence.Packages...)
+		s.Accessories = append(s.Accessories, s.Sequence.Accessories...)
+		s.Cmds = append(s.Cmds, s.Sequence.Cmds...)
+		s.PackagesNoRecommends = append(s.PackagesNoRecommends, s.Sequence.PackagesNoInstallRecommends...)
+	}
+	if s.Finalize != nil {
+		s.Cmds = append(s.Cmds, s.Finalize.Cmds...)
+	}
 }

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -50,6 +50,7 @@ func loadSuit(yamlFile string) (*Suit, error) {
 	if err := yaml.Unmarshal(data, &suit); err != nil {
 		return nil, err
 	}
+	suit.normalize()
 
 	return &suit, nil
 }
@@ -84,6 +85,16 @@ func getAvailablePackages() map[string]struct{} {
 }
 
 func installWithRetries(packages []string, retries int) {
+	installPackagesImpl(packages, retries, false)
+}
+
+// installNoRecommends installa pacchetti con --no-install-recommends,
+// usato dai costume che dichiarano packages_no_install_recommends.
+func installNoRecommends(packages []string) {
+	installPackagesImpl(packages, 3, true)
+}
+
+func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 	if len(packages) == 0 {
 		return
 	}
@@ -119,7 +130,11 @@ func installWithRetries(packages []string, retries int) {
 	}
 
 	pkgString := strings.Join(toInstall, " ")
-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install -y %s", pkgString)
+	flags := "-y"
+	if noRecommends {
+		flags = "-y --no-install-recommends"
+	}
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install %s %s", flags, pkgString)
 
 	for i := 1; i <= retries; i++ {
 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -49,15 +49,29 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 	copySkelToUser()
 
 	utils.LogNormal("✅ Costume applied successfully!")
+
+	if suit.Reboot {
+		utils.LogNormal(utils.ColorYellow + "This costume recommends a reboot to finish applying all changes." + utils.ColorReset)
+	}
+
 	return nil
 }
 
 func applySuit(dir string, suit *Suit) error {
+	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
+		setupRepositories(suit.Sequence.Repositories, suit.Name)
+	}
+
 	if len(suit.Packages) > 0 {
 		utils.LogNormal("[%s] Attempting package installation: %v", suit.Name, suit.Packages)
 		installWithRetries(suit.Packages, 3)
 	} else {
 		utils.LogNormal("[%s] No packages to install.", suit.Name)
+	}
+
+	if len(suit.PackagesNoRecommends) > 0 {
+		utils.LogNormal("[%s] Installing packages without recommends: %v", suit.Name, suit.PackagesNoRecommends)
+		installNoRecommends(suit.PackagesNoRecommends)
 	}
 
 	sysrootPath := filepath.Join(dir, "sysroot")


### PR DESCRIPTION
The Suit struct only parsed the flat schema (top-level packages/ accessories/cmds), which matches colibri's index.yaml. Every other costume in oa-wardrobe (owl, duck, chicks, albatros, eagle, gypaetus, seagull) uses a nested schema (sequence.packages, sequence.repositories, finalize.cmds, etc.), so those fields were silently dropped by YAML unmarshaling and 'coa wardrobe wear' did nothing beyond the sysroot overlay for them.

This adds Sequence/Repositories/Finalize types matching the nested schema, a normalize() step that merges both schemas into the existing flat fields so applySuit stays unaware of which form was used, and wires up what was previously ignored:
  - sequence.repositories: enables apt components on sources.list, runs sources_list_d commands, apt-get update/upgrade
  - sequence.packages_no_install_recommends
  - top-level reboot: true (logs a suggestion, does not force a reboot)

colibri's flat schema is untouched and keeps working as before.

Tested on Devuan Daedalus: 'coa wardrobe wear owl' now installs packages, adds the Quirinux repo and runs finalize commands, instead of only copying the sysroot overlay.