### PR TITLE
Fix wardrobe root without sudo

### DIFF
--- a/coa/pkg/tailor/get-wardrobe-root.go
+++ b/coa/pkg/tailor/get-wardrobe-root.go
@@ -3,28 +3,40 @@ package tailor
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 )
 
 func getWardrobeRoot() (string, error) {
-	var homeDir string
-
-	sudoUser := os.Getenv("SUDO_USER")
-	if sudoUser != "" {
-		u, err := user.Lookup(sudoUser)
-		if err == nil {
-			homeDir = u.HomeDir
+	// 1. sudo: SUDO_USER identifica al usuario real detrás de la elevación.
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		if u, err := user.Lookup(sudoUser); err == nil {
+			return filepath.Join(u.HomeDir, ".oa-wardrobe"), nil
 		}
 	}
 
-	if homeDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("unable to determine home directory: %v", err)
+	// 2. Distros sin sudo (Quirinux entre otras, que usan 'su' o similar)
+	// no setean SUDO_USER, y $HOME bajo 'su' suele quedar en /root -- ahí
+	// es donde 'coa wardrobe wear' terminaba escribiendo/leyendo por error.
+	// 'logname' consulta el loginuid de auditoría del kernel, que identifica
+	// a quien inició sesión originalmente sin importar cuántos 'su' haya
+	// en el medio.
+	if out, err := exec.Command("logname").Output(); err == nil {
+		login := strings.TrimSpace(string(out))
+		if login != "" && login != "root" {
+			if u, err := user.Lookup(login); err == nil {
+				return filepath.Join(u.HomeDir, ".oa-wardrobe"), nil
+			}
 		}
-		homeDir = home
 	}
 
-	return filepath.Join(homeDir, ".oa-wardrobe"), nil
+	// 3. Último recurso: HOME del proceso actual (caso normal, sin elevar
+	// privilegios en absoluto).
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %v", err)
+	}
+	return filepath.Join(home, ".oa-wardrobe"), nil
 }

--- a/coa/pkg/tailor/repositories.go
+++ b/coa/pkg/tailor/repositories.go
@@ -38,7 +38,7 @@ func setupRepositories(repos *Repositories, suitName string) {
 
 	if repos.Upgrade {
 		logToFile(WarnPrefix(suitName) + "apt-get upgrade...")
-		utils.Exec("DEBIAN_FRONTEND=noninteractive apt-get upgrade -y")
+		utils.Exec("DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' upgrade -y")
 	}
 }
 

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -134,7 +134,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 	if noRecommends {
 		flags = "-y --no-install-recommends"
 	}
-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install %s %s", flags, pkgString)
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
 
 	for i := 1; i <= retries; i++ {
 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))


### PR DESCRIPTION
Distributions without sudo (e.g., Quirinux and others that rely on 'su' or similar) do not set SUDO_USER, and when running under 'su', $HOME typically remains set to /root. As a result, 'coa wardrobe wear' would incorrectly read from and write to that location. 'logname' queries the kernel audit loginuid, which identifies the user who originally authenticated, regardless of how many 'su' transitions occurred in the meantime.
