### PR TITLE
tailor: require root upfront instead of failing halfway through apt/r…

### DIFF
--- a/coa/pkg/tailor/get-wardrobe-root.go
+++ b/coa/pkg/tailor/get-wardrobe-root.go
@@ -1,19 +1,41 @@
 package tailor
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
+	"strings"
 )
 
+// getWardrobeRoot devuelve ~/.oa-wardrobe del usuario "real" que está
+// detrás de esta ejecución.
+//
+// Con 'sudo coa wardrobe wear ...' alcanza con SUDO_USER. Pero
+// 'coa wardrobe wear' ahora exige euid 0 (ver Wear() en wear.go), y en
+// distros como Quirinux, que no traen sudo configurado por defecto, la
+// forma normal de llegar a ese euid 0 es 'su' -- que NO define
+// SUDO_USER. En ese caso, os.UserHomeDir() devuelve /root, y coa
+// terminaba buscando el wardrobe en /root/.oa-wardrobe en vez de en el
+// home real donde el usuario lo clonó (p.ej. /home/quirinux2).
+//
+// Por eso, sin SUDO_USER, buscamos el primer usuario humano real en
+// /etc/passwd (UID 1000-59999, shell de login válida) antes de resignarnos
+// a usar el home del proceso actual.
 func getWardrobeRoot() (string, error) {
 	var homeDir string
 
 	sudoUser := os.Getenv("SUDO_USER")
 	if sudoUser != "" {
-		u, err := user.Lookup(sudoUser)
-		if err == nil {
+		if u, err := user.Lookup(sudoUser); err == nil {
+			homeDir = u.HomeDir
+		}
+	}
+
+	if homeDir == "" {
+		if u := firstHumanUser(); u != nil {
 			homeDir = u.HomeDir
 		}
 	}
@@ -27,4 +49,34 @@ func getWardrobeRoot() (string, error) {
 	}
 
 	return filepath.Join(homeDir, ".oa-wardrobe"), nil
+}
+
+// firstHumanUser busca el primer usuario real (no de sistema) en
+// /etc/passwd: UID entre 1000 y 59999, con una shell de login válida.
+func firstHumanUser() *user.User {
+	f, err := os.Open("/etc/passwd")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Split(scanner.Text(), ":")
+		if len(fields) < 7 {
+			continue
+		}
+		uid, err := strconv.Atoi(fields[2])
+		if err != nil || uid < 1000 || uid >= 60000 {
+			continue
+		}
+		shell := fields[6]
+		if strings.HasSuffix(shell, "nologin") || strings.HasSuffix(shell, "/false") {
+			continue
+		}
+		if u, err := user.Lookup(fields[0]); err == nil {
+			return u
+		}
+	}
+	return nil
 }

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -197,7 +197,7 @@ func printAiPrompt(packages []string) {
 		logToFile(fmt.Sprintf("Error creating AIPrompt.txt: %v", err))
 	} else {
 		if sudoUser != "" {
-			utils.Exec(fmt.Sprintf("sudo chown %s:%s %s", sudoUser, sudoUser, promptFile))
+			utils.Exec(fmt.Sprintf("chown %s:%s %s", sudoUser, sudoUser, promptFile))
 		}
 		logToFile(fmt.Sprintf("✅ AIPrompt.txt file generated at: %s", promptFile))
 		utils.LogNormal("Prompt file generated in Home: %s%s%s\n", utils.ColorYellow, promptFile, utils.ColorReset)

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -106,11 +106,26 @@ func applySuit(dir string, suit *Suit) error {
 
 func copySkelToUser() {
 	userHome, _ := os.UserHomeDir()
+	targetUser := os.Getenv("SUDO_USER")
+	if targetUser == "" {
+		targetUser = os.Getenv("USER")
+	}
 	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
 		userHome = filepath.Join("/home", sudoUser)
 	}
 
+	if targetUser == "" || targetUser == "root" {
+		utils.LogNormal("WARNING: unable to determine a non-root target user, skipping /etc/skel sync to avoid leaving files owned by root")
+		return
+	}
+
 	utils.LogNormal("Syncing /etc/skel -> %s", userHome)
-	cmd := fmt.Sprintf("sudo rsync -a /etc/skel/ %s/", userHome)
+	// IMPORTANTE: 'rsync -a' preserva dueño/grupo del ORIGEN (/etc/skel,
+	// propiedad de root). Sin --chown, cualquier archivo o carpeta que ya
+	// existiera en el home del usuario (incluido el home mismo) quedaba
+	// con su metadata de propietario reescrita a root en cuanto rsync la
+	// tocaba, aunque el contenido no cambiara. --no-o --no-g --chown fija
+	// el dueño real de destino explícitamente en vez de heredarlo.
+	cmd := fmt.Sprintf("sudo rsync -a --no-o --no-g --chown=%s:%s /etc/skel/ %s/", targetUser, targetUser, userHome)
 	utils.Exec(cmd)
 }

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -8,6 +8,11 @@ import (
 )
 
 func Wear(costumeName string, noAcc bool, noFirm bool) error {
+	if os.Geteuid() != 0 {
+		utils.LogError("'coa wardrobe wear' needs to install packages and write to system paths; run it as root (e.g. 'su' first, or 'sudo coa wardrobe wear %s' if sudo is configured for your user).", costumeName)
+		return fmt.Errorf("must be run as root")
+	}
+
 	utils.LogNormal("Starting costume application for: %s", costumeName)
 
 	root, err := getWardrobeRoot()
@@ -83,7 +88,7 @@ func applySuit(dir string, suit *Suit) error {
 		utils.LogNormal("[%s] Overlay folder found: %s", suit.Name, sysrootPath)
 		utils.LogNormal("[%s] Running rsync to root /...", suit.Name)
 
-		cmd := fmt.Sprintf("sudo rsync -aAXv %s/ /", sysrootPath)
+		cmd := fmt.Sprintf("rsync -aAXv %s/ /", sysrootPath)
 		if err := utils.Exec(cmd); err != nil {
 			utils.LogNormal("[%s] Error during overlay: %v", suit.Name, err)
 		} else {
@@ -105,12 +110,30 @@ func applySuit(dir string, suit *Suit) error {
 }
 
 func copySkelToUser() {
-	userHome, _ := os.UserHomeDir()
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		userHome = filepath.Join("/home", sudoUser)
+	targetUser := os.Getenv("SUDO_USER")
+	userHome := ""
+
+	if targetUser != "" {
+		userHome = filepath.Join("/home", targetUser)
+	} else if u := firstHumanUser(); u != nil {
+		// Sin SUDO_USER (p.ej. se entró con 'su' en vez de 'sudo'), no
+		// hay que confiar en $USER: 'su' normalmente lo pisa a "root".
+		targetUser = u.Username
+		userHome = u.HomeDir
+	}
+
+	if targetUser == "" || targetUser == "root" {
+		utils.LogNormal("WARNING: unable to determine a non-root target user, skipping /etc/skel sync to avoid leaving files owned by root")
+		return
 	}
 
 	utils.LogNormal("Syncing /etc/skel -> %s", userHome)
-	cmd := fmt.Sprintf("sudo rsync -a /etc/skel/ %s/", userHome)
+	// IMPORTANTE: 'rsync -a' preserva dueño/grupo del ORIGEN (/etc/skel,
+	// propiedad de root). Sin --chown, cualquier archivo o carpeta que ya
+	// existiera en el home del usuario (incluido el home mismo) quedaba
+	// con su metadata de propietario reescrita a root en cuanto rsync la
+	// tocaba, aunque el contenido no cambiara. --no-o --no-g --chown fija
+	// el dueño real de destino explícitamente en vez de heredarlo.
+	cmd := fmt.Sprintf("rsync -a --no-o --no-g --chown=%s:%s /etc/skel/ %s/", targetUser, targetUser, userHome)
 	utils.Exec(cmd)
 }


### PR DESCRIPTION
…sync, and resolve the real user's home even without SUDO_USER

'coa wardrobe wear' ran apt-get/dpkg without any privilege check, and only prefixed 'sudo' on some rsync/chown calls -- inconsistent, and it assumes sudo is installed and configured for the invoking user, which is NOT the case on Quirinux by design (no sudo group/config out of the box; users 'su' to root instead).

Now checks os.Geteuid() == 0 once at the top of Wear() and fails fast with a clear message if not root, instead of limping through a dozen failed privileged calls first. The internal 'sudo' prefixes are removed since they're redundant (and can themselves fail without sudo installed) once root is already guaranteed.

Separately: getWardrobeRoot() and copySkelToUser() relied on SUDO_USER/$USER to find the real user's home directory. Both are only set by 'sudo', not by 'su' -- so entering a root shell via 'su' (the normal way on a distro without sudo configured) made coa look for the wardrobe in /root instead of the user's actual home, and silently skip copying /etc/skel. Both now fall back to the first real human account found in /etc/passwd (UID 1000-59999, valid login shell) when SUDO_USER isn't set.