### PR TITLE
remaster: support vendor-supplied GRUB/ISOLINUX theme and menu labels

### DIFF
--- a/coa/brain.d/base.yaml.tmpl
+++ b/coa/brain.d/base.yaml.tmpl
@@ -46,7 +46,8 @@ remaster:
       command: |
         [ -f "/etc/penguins-eggs.d/brain.d/assets/splash.png" ] && cp -f /etc/penguins-eggs.d/brain.d/assets/splash.png /home/eggs/isodir/boot/grub/splash.png
         [ -f "/etc/penguins-eggs.d/brain.d/assets/splash.png" ] && cp -f /etc/penguins-eggs.d/brain.d/assets/splash.png /home/eggs/isodir/isolinux/splash.png
-
+        [ -f "/etc/penguins-eggs.d/brain.d/assets/grub-theme.cfg" ] && cp -f /etc/penguins-eggs.d/brain.d/assets/grub-theme.cfg /home/eggs/isodir/boot/grub/theme.cfg
+        [ -f "/etc/penguins-eggs.d/brain.d/assets/isolinux-theme.cfg" ] && cp -f /etc/penguins-eggs.d/brain.d/assets/isolinux-theme.cfg /home/eggs/isodir/isolinux/isolinux.theme.cfg
         if [ -f "/usr/share/grub/unicode.pf2" ]; then
             cp -f /usr/share/grub/unicode.pf2 /home/eggs/isodir/boot/grub/font.pf2
         elif [ -f "/etc/penguins-eggs.d/brain.d/assets/unicode.pf2" ]; then

--- a/coa/pkg/assets/configs/scripts/generate-menus.sh
+++ b/coa/pkg/assets/configs/scripts/generate-menus.sh
@@ -6,6 +6,7 @@ ISODIR="$1"
 PRETTY_NAME=$(grep ^PRETTY_NAME= /etc/os-release | cut -d= -f2 | tr -d '"')
 BOOT_PARAMS="$2"
 BOOT_COMMON="audit=0 splash quiet loglevel=3 systemd.show_status=auto udev.log_priority=3"
+RAM_MODE_ENABLED="${3:-1}"
 
 echo "Generazione menu per: $PRETTY_NAME"
 
@@ -16,10 +17,60 @@ fi
 
 echo "Generazione menu GRUB e ISOLINUX in corso..."
 
+MENU_TITLE="penguins-eggs (oa edition)"
+START_LABEL="Start"
+RAM_LABEL="RAM mode"
+if [ -f "/etc/penguins-eggs.d/brain.d/assets/menu-strings.conf" ]; then
+    . "/etc/penguins-eggs.d/brain.d/assets/menu-strings.conf"
+fi
+
+GRUB_RAM_ENTRY=""
+ISOLINUX_RAM_ENTRY=""
+if [ "$RAM_MODE_ENABLED" = "1" ]; then
+    GRUB_RAM_ENTRY="menuentry \"$START_LABEL $PRETTY_NAME - $RAM_LABEL\" {
+    linux /live/vmlinuz $BOOT_PARAMS $BOOT_COMMON toram
+    initrd /live/initrd.img
+}"
+    ISOLINUX_RAM_ENTRY="
+LABEL ram
+    MENU LABEL $START_LABEL $PRETTY_NAME - $RAM_LABEL
+    LINUX /live/vmlinuz
+    APPEND $BOOT_PARAMS $BOOT_COMMON toram
+    INITRD /live/initrd.img"
+fi
+
+GRUB_THEME_BLOCK="background_image /boot/grub/splash.png
+
+# ==========================================
+# COLORI MENU PRINCIPALE
+# ==========================================
+set menu_color_normal=white/black
+set menu_color_highlight=white/blue
+
+# ==========================================
+# COLORI EDITOR E TERMINALE
+# ==========================================
+set color_normal=white/black
+set color_highlight=white/blue"
+GRUB_HEADER_ENTRIES="menuentry \"--- $MENU_TITLE ---\" {
+    true
+}
+menuentry \"\" {
+    true
+}"
+GRUB_DEFAULT_INDEX=2
+
+if [ -f "$ISODIR/boot/grub/theme.cfg" ]; then
+    GRUB_THEME_BLOCK="insmod gfxmenu
+set theme=/boot/grub/theme.cfg"
+    GRUB_HEADER_ENTRIES=""
+    GRUB_DEFAULT_INDEX=0
+fi
+
 # 1. Generazione GRUB.cfg principale
 cat <<EOF > "$ISODIR/boot/grub/grub.cfg"
 set timeout=5
-set default=2
+set default=$GRUB_DEFAULT_INDEX
 
 insmod efi_gop
 insmod efi_uga
@@ -38,56 +89,37 @@ if loadfont /boot/grub/font.pf2; then
     terminal_output gfxterm
 fi
 
-background_image /boot/grub/splash.png
+$GRUB_THEME_BLOCK
 
-# ==========================================
-# COLORI MENU PRINCIPALE
-# ==========================================
-set menu_color_normal=white/black
-set menu_color_highlight=white/blue
-
-# ==========================================
-# COLORI EDITOR E TERMINALE
-# ==========================================
-set color_normal=white/black
-set color_highlight=white/blue
-
-menuentry "--- penguins-eggs (oa edition) ---" {
-    true
-}
-menuentry "" {
-    true
-}
-menuentry "Start $PRETTY_NAME" {
+$GRUB_HEADER_ENTRIES
+menuentry "$START_LABEL $PRETTY_NAME" {
     linux /live/vmlinuz $BOOT_PARAMS $BOOT_COMMON
     initrd /live/initrd.img
 }
-menuentry "Start $PRETTY_NAME - RAM mode" {
-    linux /live/vmlinuz $BOOT_PARAMS $BOOT_COMMON toram
-    initrd /live/initrd.img
-}
+$GRUB_RAM_ENTRY
 EOF
 
 # 2. Generazione ISOLINUX.cfg
+ISOLINUX_HEADER="MENU BACKGROUND splash.png
+MENU TITLE $MENU_TITLE"
+
+if [ -f "$ISODIR/isolinux/isolinux.theme.cfg" ]; then
+    ISOLINUX_HEADER="include isolinux.theme.cfg"
+fi
+
 cat <<EOF > "$ISODIR/isolinux/isolinux.cfg"
 UI vesamenu.c32
 TIMEOUT 50
 DEFAULT live
 
-MENU BACKGROUND splash.png
-MENU TITLE penguins-eggs (oa edition)
+$ISOLINUX_HEADER
 
 LABEL live
-    MENU LABEL Start $PRETTY_NAME
+    MENU LABEL $START_LABEL $PRETTY_NAME
     LINUX /live/vmlinuz
     APPEND $BOOT_PARAMS $BOOT_COMMON
     INITRD /live/initrd.img
-
-LABEL ram
-    MENU LABEL Start $PRETTY_NAME - RAM mode
-    LINUX /live/vmlinuz
-    APPEND $BOOT_PARAMS $BOOT_COMMON toram
-    INITRD /live/initrd.img
+$ISOLINUX_RAM_ENTRY
 EOF
 
 # 3. Trampolino EFI (Attenzione agli escape \$ per preservare le variabili per GRUB)


### PR DESCRIPTION
Both are opt-in and read only if the vendor costume ships them under /etc/penguins-eggs.d/brain.d/assets/ (boot-assets stages them into the ISO):

- grub-theme.cfg / isolinux-theme.cfg -> enable GRUB's gfxmenu theme engine and ISOLINUX's native 'include', instead of the flat background+colors used today.
- menu-strings.conf -> overrides MENU_TITLE/START_LABEL/RAM_LABEL (e.g. for translation), sourced as a plain shell snippet.

No vendor file present -> byte-identical behaviour to before.

remaster: skip redundant GRUB header entry when a vendor theme is active

The gfxmenu theme already shows the product title at the top of the screen (title-text in theme.cfg), so the flat '--- MENU_TITLE ---' placeholder entry duplicated it. Now omitted when boot/grub/theme.cfg is present, with 'set default' adjusted accordingly (0 instead of 2, since the two placeholder entries no longer occupy slots 0-1).