### PR TITLE
brain: recognize Quirinux as debian-family for module selection

### DIFF
--- a/coa/brain.d/index.yaml
+++ b/coa/brain.d/index.yaml
@@ -1,7 +1,7 @@
 # Mappatura: a quale file .yaml corrisponde ogni ID o ID_LIKE
 distributions:
   - id: "debian"
-    like: ["ubuntu", "linuxmint", "kali", "pop", "devuan"]
+    like: ["ubuntu", "linuxmint", "kali", "pop", "devuan", "quirinux"]
     file: "debian.bash.tmpl"
   
   - id: "arch"


### PR DESCRIPTION
Same class of bug as devuan-module-mapping (#48): DetectAndLoad (coa/pkg/parser/parser.go) matches distro modules against the raw /etc/os-release ID via brain.d/index.yaml, independently of the FamilyID/ID_LIKE resolution in coa/pkg/distro/distro.go.

Quirinux (ID=quirinux, ID_LIKE=debian) resolves correctly to family 'debian' in distro.go, but was missing from index.yaml's 'like' list, so 'eggs produce'/'coa remaster' failed with 'no module found for Debian (ID: quirinux)' on any system remastered after 'coa wardrobe wear quirinux' (which pulls in the real quirinux-config package, setting os-release ID=quirinux).

debian.bash.tmpl has no systemd dependency and needs no changes for this, same as the devuan fix -- pure mapping addition.