### PR TITLE
config: fix TUI navigation skipping hidden fields in the wrong direction

### DIFF
--- a/coa/pkg/cmd/config.go
+++ b/coa/pkg/cmd/config.go
@@ -217,23 +217,15 @@ func (m *configModel) onTabSwitch() tea.Cmd {
 	return nil
 }
 
-func (m *configModel) focusField(idx int) tea.Cmd {
+func (m *configModel) focusField(idx int, direction int) tea.Cmd {
 	m.focus = (idx + cfgFieldCount) % cfgFieldCount
 	for {
 		if m.focus == cfgLevel && !m.showLevel() {
-			if idx <= cfgLevel {
-				m.focus = (m.focus - 1 + cfgFieldCount) % cfgFieldCount
-			} else {
-				m.focus = (m.focus + 1) % cfgFieldCount
-			}
+			m.focus = (m.focus + direction + cfgFieldCount) % cfgFieldCount
 			continue
 		}
 		if m.focus == cfgInstaller && !isDesktopConfig() {
-			if idx <= cfgInstaller {
-				m.focus = (m.focus - 1 + cfgFieldCount) % cfgFieldCount
-			} else {
-				m.focus = (m.focus + 1) % cfgFieldCount
-			}
+			m.focus = (m.focus + direction + cfgFieldCount) % cfgFieldCount
 			continue
 		}
 		break
@@ -252,9 +244,9 @@ func (m configModel) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	switch key {
 	case "up":
-		return m, m.focusField(m.focus - 1)
+		return m, m.focusField(m.focus-1, -1)
 	case "down":
-		return m, m.focusField(m.focus + 1)
+		return m, m.focusField(m.focus+1, 1)
 	case "left", "right":
 		if m.focus == cfgAlgorithm {
 			delta := 1


### PR DESCRIPTION
focusField() tried to infer navigation direction by comparing the target index against the hidden field's position (cfgLevel or cfgInstaller). That comparison is ambiguous whenever the target index happens to equal the hidden field's own position -- which is exactly what happens on the single most common case, moving one step and landing directly on it.

Concretely: switching Algorithm away from 'zstd' hides the Level field. Pressing 'down' from Algorithm then computed the same target index as pressing 'up' from ISO Prefix would, so the ambiguous comparison always resolved to 'go backward', trapping the cursor on Algorithm instead of advancing to ISO Prefix.

focusField now takes the real movement direction explicitly instead of re-deriving it, and keeps stepping in that direction through any hidden fields.