### PR TITLE
sysinstall: let vendors override Calamares users.conf and password UI

### DIFF
--- a/coa/pkg/sysinstall/setup/template/users.conf.tmpl
+++ b/coa/pkg/sysinstall/setup/template/users.conf.tmpl
@@ -16,7 +16,7 @@ sudoersConfigureWithGroup: false
 
 # --- IL FIX PER LE PASSWORD ---
 # Permettiamo esplicitamente password deboli e lo impostiamo come default
-allowWeakPasswords: true
+allowWeakPasswords: {{ .AllowWeakPasswords }}
 allowWeakPasswordsDefault: true
 
 passwordRequirements:

--- a/coa/pkg/sysinstall/setup/user-conf.go
+++ b/coa/pkg/sysinstall/setup/user-conf.go
@@ -1,33 +1,51 @@
 package setup
 
 import (
+	"bufio"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
 
-// UserConfig contiene i dati da iniettare nel template YAML
+// UserConfig contains the data to inject into the YAML template
 type UserConfig struct {
-	Date       string
-	Groups     []string
-	AdminGroup string
+	Date               string
+	Groups             []string
+	AdminGroup         string
+	AllowWeakPasswords bool
 }
 
 func userConf() error {
-	// 1. Identifichiamo l'utente live
+	targetPath := filepath.Join(InstallerDRoot, "modules", "users.conf")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		return err
+	}
+
+	// If the vendor wardrobe ships a complete users.conf override under
+	// /etc/penguins-eggs.d/brain.d/assets/calamares/users.conf, copy it
+	// directly to the installer modules directory and return -- no need
+	// to render the template at all.
+	vendorUsersConf := "/etc/penguins-eggs.d/brain.d/assets/calamares/users.conf"
+	if data, err := os.ReadFile(vendorUsersConf); err == nil {
+		return os.WriteFile(targetPath, data, 0644)
+	}
+
+	// 1. Identify the live user
 	liveUser := os.Getenv("SUDO_USER")
 	if liveUser == "" || liveUser == "root" {
 		liveUser = "live"
 	}
 
-	// 2. Leggiamo i gruppi reali
+	// 2. Read the real groups
 	cmd := exec.Command("id", "-Gn", liveUser)
 	out, err := cmd.Output()
 
 	var validGroups []string
-	adminGroup := "wheel" // Default universale
+	adminGroup := "wheel" // Universal default
 
 	if err == nil {
 		rawGroups := strings.Fields(string(out))
@@ -40,7 +58,7 @@ func userConf() error {
 			}
 		}
 	} else {
-		// Fallback di emergenza
+		// Emergency fallback
 		wishlist := []string{"users", "wheel", "sudo", "audio", "video", "storage", "network", "lp", "scanner"}
 		data, _ := os.ReadFile("/etc/group")
 		content := string(data)
@@ -54,18 +72,53 @@ func userConf() error {
 		}
 	}
 
-	// 3. Prepariamo la struttura dati
+	// 3. The "require strong passwords" checkbox is visible by default
+	// (Piero's original choice). A vendor can hide it by shipping:
+	//   /etc/penguins-eggs.d/brain.d/assets/hide-weak-password-checkbox
+	// (e.g. the 'quirinux' costume from oa-wardrobe) -- mere presence
+	// is enough, content does not matter. No vendor file -> no change.
+	allowWeakPasswords := true
+	if _, err := os.Stat("/etc/penguins-eggs.d/brain.d/assets/hide-weak-password-checkbox"); err == nil {
+		allowWeakPasswords = false
+	}
+
+	// 4. Build the data structure
 	config := UserConfig{
-		Date:       time.Now().Format("2006-01-02"),
-		Groups:     validGroups, // Passiamo l'array nudo e crudo!
-		AdminGroup: adminGroup,
+		Date:               time.Now().Format("2006-01-02"),
+		Groups:             validGroups,
+		AdminGroup:         adminGroup,
+		AllowWeakPasswords: allowWeakPasswords,
 	}
 
-	// 4. Scriviamo usando il template
-	targetPath := filepath.Join(InstallerDRoot, "modules", "users.conf")
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-		return err
-	}
-
+	// 5. Write using the template
 	return renderAndSaveEmbedded("users.conf.tmpl", targetPath, config, 0644)
 }
+
+// firstHumanUser finds the first real (non-system) user in /etc/passwd:
+// UID between 1000 and 59999, with a valid login shell.
+func firstHumanUser() *struct{ HomeDir string } {
+	f, err := os.Open("/etc/passwd")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Split(scanner.Text(), ":")
+		if len(fields) < 7 {
+			continue
+		}
+		uid, err := strconv.Atoi(fields[2])
+		if err != nil || uid < 1000 || uid >= 60000 {
+			continue
+		}
+		shell := fields[6]
+		if strings.HasSuffix(shell, "nologin") || strings.HasSuffix(shell, "/false") {
+			continue
+		}
+		return &struct{ HomeDir string }{HomeDir: "/home/" + fields[0]}
+	}
+	return nil
+}
+


### PR DESCRIPTION
Two opt-in mechanisms for vendor wardrobes, both inactive by default so Piero's original behaviour is unchanged for everyone else:

1. If /etc/penguins-eggs.d/brain.d/assets/calamares/users.conf exists (placed there by 'coa wardrobe wear'), userConf() copies it verbatim to the installer modules directory instead of rendering the template. This lets a vendor ship any users.conf they need (e.g. without passwordRequirements) without touching coa's own template.

2. If /etc/penguins-eggs.d/brain.d/assets/hide-weak-password-checkbox exists (mere presence, content ignored), allowWeakPasswords is set to false in the generated users.conf, hiding the 'Require strong passwords' checkbox from the Calamares UI.

Same opt-in pattern already used for GRUB/ISOLINUX theme and menu labels: vendor files present -> vendor behaviour; no files -> default.