### PR TITLE
sysinstall: fix extraMounts options type in mount.conf.tmpl (list -> …

### DIFF
--- a/coa/pkg/sysinstall/setup/template/mount.conf.tmpl
+++ b/coa/pkg/sysinstall/setup/template/mount.conf.tmpl
@@ -11,15 +11,13 @@ extraMounts:
     mountPoint: /sys
   - device: /dev
     mountPoint: /dev
-    options:
-      - bind
+    options: bind
   - device: tmpfs
     fs: tmpfs
     mountPoint: /run
   - device: /run/udev
     mountPoint: /run/udev
-    options:
-      - bind
+    options: bind
   - device: efivarfs
     fs: efivarfs
     mountPoint: /sys/firmware/efi/efivars


### PR DESCRIPTION
…string)

Calamares' mount module (libcalamares.utils.mount) takes options as a plain string, not a YAML list. The /dev and /run/udev bind-mount entries were emitting options as a list, which raises a Boost.Python.ArgumentError and aborts the whole install at job 9/27 (mount), right after partitioning -- confirmed against a real calamares-install.log.