### PR TITLE
remaster: make coa remaster resilient to interrupted previous runs

### DIFF
--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -34,7 +34,9 @@ for e in bin sbin lib lib64 opt root srv; do
     elif [ -d "$SRC" ]; then
         # FIX: Creiamo la directory di destinazione prima di fare il bind mount
         mkdir -p "$DST"
-        mount --bind "$SRC" "$DST"
+        # Idempotente: se un run precedente fallito ha lasciato il bind
+        # montato, non ritentiamo il mount (fallirebbe con "already mounted").
+        mountpoint -q "$DST" || mount --bind "$SRC" "$DST"
     fi
 done
 
@@ -45,8 +47,10 @@ done
 # /home, quindi un bind condiviso (default) qui genererebbe un mount-bomb.
 if [ "$MODE" = "clone" ] || [ "$MODE" = "crypted" ]; then
     mkdir -p "$LIVEROOT/home"
-    mount --bind --make-slave /home "$LIVEROOT/home"
-    mount -o remount,bind,ro "$LIVEROOT/home"
+    if ! mountpoint -q "$LIVEROOT/home"; then
+        mount --bind --make-slave /home "$LIVEROOT/home"
+        mount -o remount,bind,ro "$LIVEROOT/home"
+    fi
 fi
 
 # 4. OVERLAY PER USR E VAR
@@ -58,23 +62,23 @@ for ovlDir in usr var; do
 
     # FIX: Aggiunto $MERGED alla lista delle directory da creare
     mkdir -p "$LOWER" "$UPPER" "$WORK" "$MERGED"
-    mount --bind "/$ovlDir" "$LOWER"
-    mount -t overlay overlay -o lowerdir="$LOWER",upperdir="$UPPER",workdir="$WORK" "$MERGED"
+    mountpoint -q "$LOWER" || mount --bind "/$ovlDir" "$LOWER"
+    mountpoint -q "$MERGED" || mount -t overlay overlay -o lowerdir="$LOWER",upperdir="$UPPER",workdir="$WORK" "$MERGED"
 done
 
 # 5. API FILESYSTEMS
 # FIX: Creiamo i mount point per le API del Kernel
 mkdir -p "$LIVEROOT/proc" "$LIVEROOT/sys" "$LIVEROOT/dev" "$LIVEROOT/run"
-mount -t proc proc "$LIVEROOT/proc"
-mount -t sysfs sys "$LIVEROOT/sys"
-mount --bind /dev "$LIVEROOT/dev"
-mount --bind /run "$LIVEROOT/run"
+mountpoint -q "$LIVEROOT/proc" || mount -t proc proc "$LIVEROOT/proc"
+mountpoint -q "$LIVEROOT/sys"  || mount -t sysfs sys "$LIVEROOT/sys"
+mountpoint -q "$LIVEROOT/dev"  || mount --bind /dev "$LIVEROOT/dev"
+mountpoint -q "$LIVEROOT/run"  || mount --bind /run "$LIVEROOT/run"
 
 # 6. TMPFS
 mkdir -p "$LIVEROOT/tmp"
 chmod 1777 "$LIVEROOT/tmp"
 if [ "$GITHUB_ACTION" != "true" ]; then
-    mount -t tmpfs -o mode=1777 tmpfs "$LIVEROOT/tmp"
+    mountpoint -q "$LIVEROOT/tmp" || mount -t tmpfs -o mode=1777 tmpfs "$LIVEROOT/tmp"
 fi
 
 echo "Bootstrap completato."

--- a/coa/pkg/utils/ensure-bootloaders.go
+++ b/coa/pkg/utils/ensure-bootloaders.go
@@ -14,22 +14,33 @@ import (
 
 const BootloaderURL = "https://github.com/pieroproietti/penguins-bootloaders/releases/download/v26.1.16/bootloaders.tar.gz"
 
-// EnsureBootloaders checks if the bootloaders directory exists and is not empty.
-// If not, it downloads and extracts them.
+// completeMarker si scrive solo a estrazione riuscita: distingue una
+// cache valida da una lasciata a metà da un run precedente interrotto
+// (crash, kill, VM riavviata durante il download/estrazione).
+const completeMarker = ".download-complete"
+
+// EnsureBootloaders checks if the bootloaders directory exists and
+// contains a completed download. If not, it (re)downloads and extracts them.
 func EnsureBootloaders(targetDir string) error {
-	// 1. Check if they already exist and contain files
-	if fi, err := os.Stat(targetDir); err == nil && fi.IsDir() {
-		files, err := os.ReadDir(targetDir)
-		if err == nil && len(files) > 0 {
-			return nil
-		}
+	// 1. Check if a previous download completed successfully
+	if _, err := os.Stat(filepath.Join(targetDir, completeMarker)); err == nil {
+		return nil
 	}
 
-	LogNormal("Bootloaders not found in %s. Starting download...", targetDir)
+	LogNormal("Bootloaders not found (or incomplete) in %s. Starting download...", targetDir)
 
-	// 2. Download and extract
+	// 2. Wipe any partial leftovers from an interrupted previous run,
+	// then download and extract fresh.
+	if err := os.RemoveAll(targetDir); err != nil {
+		return fmt.Errorf("unable to clean up %s: %w", targetDir, err)
+	}
 	if err := downloadAndExtract(BootloaderURL, targetDir); err != nil {
 		return fmt.Errorf("failed to download and extract bootloaders: %w", err)
+	}
+
+	// 3. Only now, after everything extracted successfully, mark it complete.
+	if err := os.WriteFile(filepath.Join(targetDir, completeMarker), []byte("ok\n"), 0644); err != nil {
+		return fmt.Errorf("unable to write completion marker: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Two independent failure points, both caused by an earlier run being killed, crashing, or the VM restarting mid-remaster:

- bootstrap-liveroot.sh mounted proc/sys/dev/run and the usr/var overlays unconditionally. A leftover mount from a previous run made the next 'coa remaster' fail immediately with 'already mounted' (exit 32), aborting before reaching any real work. Every mount call now checks 'mountpoint -q' first.

- EnsureBootloaders only checked whether the bootloaders cache directory had any files in it, not whether the download+extraction had actually completed. A partial cache (e.g. missing ISOLINUX/isolinux.bin) was trusted as-is, failing later at bootloader-copy instead of at the real cause. A .download-complete marker, written only after a fully successful extraction, now drives that decision -- its absence forces a clean re-download.