### PR TITLE
brain: fix autologin never actually applying (missing chroot + hardco…

### DIFF
--- a/coa/brain.d/base.yaml.tmpl
+++ b/coa/brain.d/base.yaml.tmpl
@@ -232,8 +232,9 @@ remaster:
   - name: autologin-gui
     description: "Set up autologin for the live user"
     module: "autologin-gui"
+    chroot: true
     params:
-      user: "live"
+      user: "{{.LiveUser}}"
       is_gui: true
 
 # ----------------------------------------------------------------------------

--- a/coa/pkg/parser/parser.go
+++ b/coa/pkg/parser/parser.go
@@ -73,9 +73,15 @@ func DetectAndLoad(isGitHubAction bool) (*Profile, error) {
 
 	utils.LogNormal("%s[parser]%s Compilazione: base.yaml.tmpl + %s", utils.ColorCyan, utils.ColorReset, moduleFile)
 
-	ramModeEnabled := true
-	if settings, err := LoadCustomSettings(); err == nil && settings != nil && settings.Remaster.RamMode != nil {
-		ramModeEnabled = *settings.Remaster.RamMode
+ramModeEnabled := true
+	liveUser := "live"
+	if settings, err := LoadCustomSettings(); err == nil && settings != nil {
+		if settings.Remaster.RamMode != nil {
+			ramModeEnabled = *settings.Remaster.RamMode
+		}
+		if settings.Remaster.User != "" {
+			liveUser = settings.Remaster.User
+		}
 	}
 
 	ctx := TemplateContext{
@@ -83,6 +89,7 @@ func DetectAndLoad(isGitHubAction bool) (*Profile, error) {
 		DistroID:       myDistro.DistroID,
 		IsGitHubAction: isGitHubAction,
 		RamModeEnabled: ramModeEnabled,
+		LiveUser:       liveUser,
 	}
 
 	tmpl := template.New(filepath.Base(basePath))

--- a/coa/pkg/parser/types.go
+++ b/coa/pkg/parser/types.go
@@ -58,6 +58,7 @@ type TemplateContext struct {
 	DistroID       string
 	IsGitHubAction bool
 	RamModeEnabled bool
+	LiveUser       string
 }
 
 type BrainIndex struct {

--- a/coa/pkg/worker/autologin-gui.go
+++ b/coa/pkg/worker/autologin-gui.go
@@ -25,7 +25,7 @@ func RunAutologin(payload []byte) error {
 	user := config.Params.User
 
 	if user == "" {
-		user = "pippo"
+		user = "live"
 	}
 
 	fmt.Printf("📦 [worker] Running autologin-gui for user '%s'\n", user)


### PR DESCRIPTION
…ded user)

Two bugs compounding into 'autologin never works':

1. The autologin-gui step didn't declare 'chroot: true', so generate-plan.go never populated LiveRoot for it. RunAutologin received live_root="" and built every path (etc/lightdm, usr/share/xsessions, etc.) relative to wherever coa's own process happened to be running, not the actual live system -- silently finding nothing and configuring nothing, with no error at all.

2. Independently, 'user: "live"' was hardcoded in the YAML, ignoring any custom username set via custom.yaml (config-custom-live-user). TemplateContext now carries LiveUser, read the same way mergeCustomSettings already does elsewhere.

Also replaced RunAutologin's hardcoded 'pippo' fallback with 'live'.