### PR TITLE
config: allow disabling the 'RAM mode' boot entry

### DIFF
--- a/coa/brain.d/base.yaml.tmpl
+++ b/coa/brain.d/base.yaml.tmpl
@@ -66,6 +66,7 @@ remaster:
       args:
         - "/home/eggs/isodir"
         - '{{ template "distro_boot_params" . }}'
+        - '{{ if .RamModeEnabled }}1{{ else }}0{{ end }}'
 
 # ----------------------------------------------------------------------------
 # 6. USER IDENTITY

--- a/coa/pkg/assets/configs/scripts/generate-menus.sh
+++ b/coa/pkg/assets/configs/scripts/generate-menus.sh
@@ -24,6 +24,9 @@ if [ -f "/etc/penguins-eggs.d/brain.d/assets/menu-strings.conf" ]; then
     . "/etc/penguins-eggs.d/brain.d/assets/menu-strings.conf"
 fi
 
+# Optional "RAM mode" entry: some vendors (systems typically installed
+# on low-RAM hardware) prefer to omit it to avoid confusion.
+# Controlled via 'coa config' (custom.yaml: ram_mode).
 GRUB_RAM_ENTRY=""
 ISOLINUX_RAM_ENTRY=""
 if [ "$RAM_MODE_ENABLED" = "1" ]; then

--- a/coa/pkg/cmd/config.go
+++ b/coa/pkg/cmd/config.go
@@ -36,6 +36,7 @@ const (
 	cfgAlgorithm
 	cfgLevel
 	cfgISOPrefix
+	cfgRamMode
 	cfgInstaller
 	cfgFieldCount
 )
@@ -64,6 +65,7 @@ type configModel struct {
 	inputs  []textinput.Model
 	algoIdx int
 	instIdx int // 0 for krill, 1 for calamares
+	ramModeIdx int // 0 for enabled, 1 for disabled
 
 	saveFocus int
 	saveErr   string
@@ -79,6 +81,7 @@ type configState struct {
 	Level     int
 	ISOPrefix string
 	Installer string
+	RamMode   bool
 }
 
 func loadConfigState() configState {
@@ -88,6 +91,7 @@ func loadConfigState() configState {
 		Algorithm: "zstd",
 		Level:     3,
 		Installer: "krill",
+		RamMode:   true,
 	}
 	settings, err := parser.LoadCustomSettings()
 	if err != nil || settings == nil {
@@ -108,6 +112,9 @@ func loadConfigState() configState {
 	state.ISOPrefix = settings.Remaster.ISOPrefix
 	if settings.Remaster.Installer != "" {
 		state.Installer = settings.Remaster.Installer
+	}
+	if settings.Remaster.RamMode != nil {
+		state.RamMode = *settings.Remaster.RamMode
 	}
 	return state
 }
@@ -155,10 +162,16 @@ func newConfigModel() configModel {
 		instIdx = 1
 	}
 
+	ramModeIdx := 0
+	if !state.RamMode {
+		ramModeIdx = 1
+	}
+
 	return configModel{
-		inputs:  inputs,
-		algoIdx: algoIdx,
-		instIdx: instIdx,
+		inputs:     inputs,
+		algoIdx:    algoIdx,
+		instIdx:    instIdx,
+		ramModeIdx: ramModeIdx,
 	}
 }
 
@@ -260,6 +273,10 @@ func (m configModel) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.instIdx = 1 - m.instIdx
 			return m, nil
 		}
+		if m.focus == cfgRamMode {
+			m.ramModeIdx = 1 - m.ramModeIdx
+			return m, nil
+		}
 	}
 
 	if ii := cfgInputIdx(m.focus); ii >= 0 {
@@ -341,6 +358,7 @@ func (m configModel) buildState() configState {
 		Level:     level,
 		ISOPrefix: strings.TrimSpace(m.inputs[3].Value()),
 		Installer: installers[m.instIdx],
+		RamMode:   m.ramModeIdx == 0,
 	}
 }
 
@@ -407,6 +425,7 @@ func (m configModel) viewSettings() string {
 		fields = append(fields, fieldDef{cfgLevel, "Level"})
 	}
 	fields = append(fields, fieldDef{cfgISOPrefix, "ISO prefix"})
+	fields = append(fields, fieldDef{cfgRamMode, "RAM mode option"})
 	if isDesktopConfig() {
 		fields = append(fields, fieldDef{cfgInstaller, "Installer"})
 	}
@@ -437,6 +456,9 @@ func (m configModel) viewSettings() string {
 		case cfgInstaller:
 			installers := []string{"krill", "calamares"}
 			val = cfgCyan.Render("‹ " + installers[m.instIdx] + " ›")
+		case cfgRamMode:
+			ramModeLabels := []string{"enabled", "disabled"}
+			val = cfgCyan.Render("‹ " + ramModeLabels[m.ramModeIdx] + " ›")
 		}
 		rows = append(rows, fmt.Sprintf("%s%-14s: %s", marker, f.label, val))
 	}
@@ -519,6 +541,9 @@ func saveConfigState(state configState) error {
 	}
 	if state.Installer != "" {
 		b.WriteString(fmt.Sprintf("  installer: \"%s\"\n", state.Installer))
+	}
+	if !state.RamMode {
+		b.WriteString("  ram_mode: false\n")
 	}
 
 	if err := os.MkdirAll("/etc/penguins-eggs.d", 0755); err != nil {

--- a/coa/pkg/parser/parser.go
+++ b/coa/pkg/parser/parser.go
@@ -73,10 +73,16 @@ func DetectAndLoad(isGitHubAction bool) (*Profile, error) {
 
 	utils.LogNormal("%s[parser]%s Compilazione: base.yaml.tmpl + %s", utils.ColorCyan, utils.ColorReset, moduleFile)
 
+	ramModeEnabled := true
+	if settings, err := LoadCustomSettings(); err == nil && settings != nil && settings.Remaster.RamMode != nil {
+		ramModeEnabled = *settings.Remaster.RamMode
+	}
+
 	ctx := TemplateContext{
 		Family:         myDistro.FamilyID,
 		DistroID:       myDistro.DistroID,
 		IsGitHubAction: isGitHubAction,
+		RamModeEnabled: ramModeEnabled,
 	}
 
 	tmpl := template.New(filepath.Base(basePath))

--- a/coa/pkg/parser/types.go
+++ b/coa/pkg/parser/types.go
@@ -44,6 +44,7 @@ type RemasterConfig struct {
 	Installer   string            `yaml:"installer,omitempty" json:"installer,omitempty" mapstructure:"installer"`
 	Compression CompressionConfig `yaml:"compression" json:"compression" mapstructure:"compression"`
 	ISOPrefix   string            `yaml:"iso_prefix,omitempty" json:"iso_prefix,omitempty" mapstructure:"iso_prefix"`
+	RamMode     *bool             `yaml:"ram_mode,omitempty" json:"ram_mode,omitempty" mapstructure:"ram_mode"`
 }
 
 type CompressionConfig struct {
@@ -56,6 +57,7 @@ type TemplateContext struct {
 	Family         string
 	DistroID       string
 	IsGitHubAction bool
+	RamModeEnabled bool
 }
 
 type BrainIndex struct {


### PR DESCRIPTION
Some vendors target hardware with very little RAM (e.g. Quirinux, commonly installed on 2GB machines) where 'RAM mode' just causes confusion or an unbootable choice, and never existed in their prior tooling. Added a toggle in 'eggs config' (custom.yaml: ram_mode, default true) that controls whether generate-menus.sh emits the 'RAM mode' entry in both grub.cfg and isolinux.cfg.