### PR TITLE
worker: apply -Xbcj x86 filter when compressing squashfs with xz

### DIFF
--- a/coa/pkg/worker/mksquashfs.go
+++ b/coa/pkg/worker/mksquashfs.go
@@ -79,7 +79,13 @@ func RunMksquashfs(payload []byte) error {
 	case "zstd":
 		args = append(args, "-comp", "zstd", "-Xcompression-level", level)
 	case "xz":
-		args = append(args, "-comp", "xz")
+		// -Xbcj x86 aplica un filtro de pre-procesamiento pensado para
+		// código x86/x86_64 (reordena offsets de saltos/llamadas para
+		// que se repitan más patrones), mejorando la compresión real de
+		// xz en un sistema Linux típico sin costo de compatibilidad:
+		// mksquashfs/unsquashfs lo soportan de forma nativa y
+		// transparente al montar/leer el squashfs resultante.
+		args = append(args, "-comp", "xz", "-Xbcj", "x86", "-Xdict-size", "1M")
 	case "gzip":
 		args = append(args, "-comp", "gzip")
 	default:


### PR DESCRIPTION
mksquashfs's xz path only passed -comp xz, missing the x86 BCJ pre-filter that meaningfully improves compression of x86_64 binaries (the bulk of a Linux system) at no compatibility cost -- mksquashfs/ unsquashfs support it natively and transparently. This is the same filter already used manually in post-build recompression workflows; baking it into the initial build avoids needing a separate decompress+recompress pass just to get it.