### PR TITLE
sysinstall: allow vendor-supplied Calamares branding assets

### DIFF
--- a/coa/pkg/sysinstall/setup/branding-desc.go
+++ b/coa/pkg/sysinstall/setup/branding-desc.go
@@ -92,5 +92,47 @@ func brandingDesc(oaVersion string) error {
 		return fmt.Errorf("unable to create branding directory: %v", err)
 	}
 
-	return renderAndSaveEmbedded("branding.desc.tmpl", targetPath, config, 0644)
+	if err := renderAndSaveEmbedded("branding.desc.tmpl", targetPath, config, 0644); err != nil {
+		return err
+	}
+
+	// 6. Sovrascriviamo/completiamo il branding generico con gli asset del
+	// vendor, se presenti. Un costume del wardrobe (es. "quirinux") puo'
+	// depositare qui logo, slideshow e un branding.desc proprio tramite il
+	// suo overlay sysroot (stessa cartella usata per lo splash di
+	// GRUB/ISOLINUX in base.yaml.tmpl), senza bisogno di alcun comando
+	// aggiuntivo oltre a 'coa wardrobe wear'.
+	vendorBranding := "/etc/penguins-eggs.d/brain.d/assets/calamares"
+	if fi, err := os.Stat(vendorBranding); err == nil && fi.IsDir() {
+		if err := copyBrandingOverlay(vendorBranding, targetDir); err != nil {
+			return fmt.Errorf("unable to apply vendor calamares branding from %s: %v", vendorBranding, err)
+		}
+	}
+
+	return nil
+}
+
+// copyBrandingOverlay copia ricorsivamente il contenuto di src dentro dst,
+// sovrascrivendo i file generati automaticamente (branding.desc incluso, se
+// il vendor ne fornisce uno proprio) e aggiungendo quelli nuovi (logo.png,
+// show.qml, immagini dello slideshow...).
+func copyBrandingOverlay(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
 }


### PR DESCRIPTION
This PR lets a vendor wardrobe supply its own Calamares branding assets (branding.desc, slideshow images) that override the ones generated by coa at installer-build time.
How it works: BuildInstaller() checks for a calamares/ subdirectory under the vendor's assets path (/etc/penguins-eggs.d/brain.d/assets/calamares/). If it finds a branding.desc there, it copies the entire directory verbatim into the installer's branding folder instead of rendering the template. No vendor assets present → identical behaviour to before.
This is the same opt-in pattern used by other vendor hooks in this series: the change is inert unless the wardrobe explicitly ships the override files.