### PR TITLE
tailor: require root upfront instead of failing halfway through apt/r…

### DIFF
--- a/coa/pkg/tailor/get-wardrobe-root.go
+++ b/coa/pkg/tailor/get-wardrobe-root.go
@@ -1,42 +1,93 @@
 package tailor
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
+// getWardrobeRoot returns ~/.oa-wardrobe for the "real" user behind this
+// elevated process.
+//
+// Priority order:
+// 1. SUDO_USER  -- set by sudo, identifies the calling user reliably.
+// 2. logname    -- reads the kernel audit loginuid; survives any number
+//                  of 'su' invocations, unlike environment variables that
+//                  each elevation mechanism may or may not preserve.
+//                  Needed for distros without sudo (e.g. Quirinux/Devuan)
+//                  where 'su' is the normal way to become root and
+//                  os.UserHomeDir() returns /root instead of the real home.
+// 3. firstHumanUser -- scan /etc/passwd for the first UID 1000-59999 with
+//                       a valid login shell, last resort before giving up.
+// 4. os.UserHomeDir() -- process HOME, works when not elevated at all.
 func getWardrobeRoot() (string, error) {
-	// 1. sudo: SUDO_USER identifica al usuario real detrás de la elevación.
+	var homeDir string
+
 	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
 		if u, err := user.Lookup(sudoUser); err == nil {
-			return filepath.Join(u.HomeDir, ".oa-wardrobe"), nil
+			homeDir = u.HomeDir
 		}
 	}
 
-	// 2. Distros sin sudo (Quirinux entre otras, que usan 'su' o similar)
-	// no setean SUDO_USER, y $HOME bajo 'su' suele quedar en /root -- ahí
-	// es donde 'coa wardrobe wear' terminaba escribiendo/leyendo por error.
-	// 'logname' consulta el loginuid de auditoría del kernel, que identifica
-	// a quien inició sesión originalmente sin importar cuántos 'su' haya
-	// en el medio.
-	if out, err := exec.Command("logname").Output(); err == nil {
-		login := strings.TrimSpace(string(out))
-		if login != "" && login != "root" {
-			if u, err := user.Lookup(login); err == nil {
-				return filepath.Join(u.HomeDir, ".oa-wardrobe"), nil
+	if homeDir == "" {
+		if out, err := exec.Command("logname").Output(); err == nil {
+			login := strings.TrimSpace(string(out))
+			if login != "" && login != "root" {
+				if u, err := user.Lookup(login); err == nil {
+					homeDir = u.HomeDir
+				}
 			}
 		}
 	}
 
-	// 3. Último recurso: HOME del proceso actual (caso normal, sin elevar
-	// privilegios en absoluto).
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("unable to determine home directory: %v", err)
+	if homeDir == "" {
+		if u := firstHumanUser(); u != nil {
+			homeDir = u.HomeDir
+		}
 	}
-	return filepath.Join(home, ".oa-wardrobe"), nil
+
+	if homeDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("unable to determine home directory: %v", err)
+		}
+		homeDir = home
+	}
+
+	return filepath.Join(homeDir, ".oa-wardrobe"), nil
+}
+
+// firstHumanUser scans /etc/passwd for the first real (non-system) user:
+// UID between 1000 and 59999 with a valid login shell.
+func firstHumanUser() *user.User {
+	f, err := os.Open("/etc/passwd")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Split(scanner.Text(), ":")
+		if len(fields) < 7 {
+			continue
+		}
+		uid, err := strconv.Atoi(fields[2])
+		if err != nil || uid < 1000 || uid >= 60000 {
+			continue
+		}
+		shell := fields[6]
+		if strings.HasSuffix(shell, "nologin") || strings.HasSuffix(shell, "/false") {
+			continue
+		}
+		if u, err := user.Lookup(fields[0]); err == nil {
+			return u
+		}
+	}
+	return nil
 }

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -197,7 +197,7 @@ func printAiPrompt(packages []string) {
 		logToFile(fmt.Sprintf("Error creating AIPrompt.txt: %v", err))
 	} else {
 		if sudoUser != "" {
-			utils.Exec(fmt.Sprintf("sudo chown %s:%s %s", sudoUser, sudoUser, promptFile))
+			utils.Exec(fmt.Sprintf("chown %s:%s %s", sudoUser, sudoUser, promptFile))
 		}
 		logToFile(fmt.Sprintf("✅ AIPrompt.txt file generated at: %s", promptFile))
 		utils.LogNormal("Prompt file generated in Home: %s%s%s\n", utils.ColorYellow, promptFile, utils.ColorReset)

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -8,6 +8,11 @@ import (
 )
 
 func Wear(costumeName string, noAcc bool, noFirm bool) error {
+	if os.Geteuid() != 0 {
+		utils.LogError("'coa wardrobe wear' needs to install packages and write to system paths; run it as root (e.g. 'su' first, or 'sudo coa wardrobe wear %s' if sudo is configured for your user).", costumeName)
+		return fmt.Errorf("must be run as root")
+	}
+
 	utils.LogNormal("Starting costume application for: %s", costumeName)
 
 	root, err := getWardrobeRoot()
@@ -83,7 +88,7 @@ func applySuit(dir string, suit *Suit) error {
 		utils.LogNormal("[%s] Overlay folder found: %s", suit.Name, sysrootPath)
 		utils.LogNormal("[%s] Running rsync to root /...", suit.Name)
 
-		cmd := fmt.Sprintf("sudo rsync -aAXv %s/ /", sysrootPath)
+		cmd := fmt.Sprintf("rsync -aAXv %s/ /", sysrootPath)
 		if err := utils.Exec(cmd); err != nil {
 			utils.LogNormal("[%s] Error during overlay: %v", suit.Name, err)
 		} else {
@@ -105,12 +110,30 @@ func applySuit(dir string, suit *Suit) error {
 }
 
 func copySkelToUser() {
-	userHome, _ := os.UserHomeDir()
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		userHome = filepath.Join("/home", sudoUser)
+	targetUser := os.Getenv("SUDO_USER")
+	userHome := ""
+
+	if targetUser != "" {
+		userHome = filepath.Join("/home", targetUser)
+	} else if u := firstHumanUser(); u != nil {
+		// Sin SUDO_USER (p.ej. se entró con 'su' en vez de 'sudo'), no
+		// hay que confiar en $USER: 'su' normalmente lo pisa a "root".
+		targetUser = u.Username
+		userHome = u.HomeDir
+	}
+
+	if targetUser == "" || targetUser == "root" {
+		utils.LogNormal("WARNING: unable to determine a non-root target user, skipping /etc/skel sync to avoid leaving files owned by root")
+		return
 	}
 
 	utils.LogNormal("Syncing /etc/skel -> %s", userHome)
-	cmd := fmt.Sprintf("sudo rsync -a /etc/skel/ %s/", userHome)
+	// IMPORTANTE: 'rsync -a' preserva dueño/grupo del ORIGEN (/etc/skel,
+	// propiedad de root). Sin --chown, cualquier archivo o carpeta que ya
+	// existiera en el home del usuario (incluido el home mismo) quedaba
+	// con su metadata de propietario reescrita a root en cuanto rsync la
+	// tocaba, aunque el contenido no cambiara. --no-o --no-g --chown fija
+	// el dueño real de destino explícitamente en vez de heredarlo.
+	cmd := fmt.Sprintf("rsync -a --no-o --no-g --chown=%s:%s /etc/skel/ %s/", targetUser, targetUser, userHome)
 	utils.Exec(cmd)
 }


### PR DESCRIPTION
…sync, and resolve the real user's home even without SUDO_USER

'coa wardrobe wear' ran apt-get/dpkg without any privilege check, and only prefixed 'sudo' on some rsync/chown calls -- inconsistent, and it assumes sudo is installed and configured for the invoking user, which is NOT the case on Quirinux by design (no sudo group/config out of the box; users 'su' to root instead).

Now checks os.Geteuid() == 0 once at the top of Wear() and fails fast with a clear message if not root, instead of limping through a dozen failed privileged calls first. The internal 'sudo' prefixes are removed since they're redundant (and can themselves fail without sudo installed) once root is already guaranteed.

Separately: getWardrobeRoot() and copySkelToUser() relied on SUDO_USER/$USER to find the real user's home directory. Both are only set by 'sudo', not by 'su' -- so entering a root shell via 'su' (the normal way on a distro without sudo configured) made coa look for the wardrobe in /root instead of the user's actual home, and silently skip copying /etc/skel. Both now fall back to the first real human account found in /etc/passwd (UID 1000-59999, valid login shell) when SUDO_USER isn't set.