### PR TITLE
fix: separate microcode initrd line from kernel line in systemd-boot entry

### DIFF
--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -309,7 +309,8 @@ fi
 
 cat <<EOF > /boot/efi/loader/entries/oa-linux.conf
 title   OA Linux
-linux   /$KERNEL_FILE$UCODE_LINE
+linux   /$KERNEL_FILE
+${UCODE_LINE}
 initrd  /$INITRD_FILE
 options root=$ROOT_PART rw $ROOTFLAGS
 EOF


### PR DESCRIPTION
## Summary
- `install_distro_systemd_boot` in `coa/brain.d/modules/arch-family.bash.tmpl` writes the systemd-boot loader entry with `linux   /$KERNEL_FILE$UCODE_LINE` — `$UCODE_LINE` already holds a full line (`"initrd  /amd-ucode.img"`), but it was glued directly onto the kernel filename with no newline, corrupting it (e.g. `vmlinuz-6.6-x86_64initrd`).
- systemd-boot silently rejects the malformed entry, so a fresh install with a microcode package present ends up with zero bootable menu entries. Only bites when the installer picks systemd-boot over GRUB, which happens whenever `bootctl` is present in the target chroot — effectively always on Arch-family systems.
- Fix: put `$UCODE_LINE` on its own line so it can never fuse with the kernel line, regardless of whether microcode is present.

## Test plan
- [x] Verified heredoc renders correctly for both cases (ucode present / absent)
- [x] Rebuilt ISO and tested in QEMU (fresh VM, fresh EFI vars/disk): confirmed systemd-boot now shows a valid "OA Linux" entry after a fresh install, boots through to login successfully

## Note
I'm new to the penguins-eggs project — really enjoying working with it so far. Happy to keep contributing fixes for issues I run into while testing on Mabox in QEMU.