### PR TITLE
fix: give Garuda's install-time dracut call an explicit initramfs path

### DIFF
--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -202,10 +202,32 @@ fi
         echo "[FATAL ERROR] Unable to determine the kernel in the chroot."
         exit 1
     fi
-    
-    # -N (no-hostonly) is vital to generate the image correctly from within the chroot
-    dracut -N -f --add "btrfs" --kver "$KVER_DIR"
-    
+
+    INITRD_TARGET="/boot/initramfs-$KVER_DIR.img"
+
+    # The distro's own kernel-package hook may have already dropped a
+    # differently-named initramfs in /boot (e.g. a pkgbase-named image built
+    # before this regen, with no btrfs support). install_distro_systemd_boot/
+    # install_distro_limine pick their INITRD_FILE via an unordered
+    # `find | head -n1` over the same glob, so a stale leftover here could be
+    # silently selected instead of the one we're about to (re)generate below.
+    find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" ! -name "$(basename "$INITRD_TARGET")" -delete
+
+    # -N (no-hostonly) is vital to generate the image correctly from within the chroot.
+    # Explicit outfile is required: Garuda's dracut.conf.d defaults to the BLS/
+    # machine-id layout under /boot/efi/<machine-id>/<kver>/, which doesn't exist
+    # yet at this point in the install and makes dracut fail outright. Naming it
+    # explicitly matches what install_distro_systemd_boot/install_distro_limine
+    # already search for (initramfs-*.img under /boot).
+    if ! dracut -N -f --add "btrfs" --kver "$KVER_DIR" "$INITRD_TARGET"; then
+        echo "[FATAL ERROR] dracut failed to generate $INITRD_TARGET"
+        exit 1
+    fi
+    if [ ! -f "$INITRD_TARGET" ]; then
+        echo "[FATAL ERROR] dracut reported success but $INITRD_TARGET is missing"
+        exit 1
+    fi
+
 {{ else }}
     echo "-> Regenerating mkinitcpio-based initramfs..."
     ROOT_FSTYPE=$(awk '$2 == "/" {print $3}' /etc/fstab)

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -205,20 +205,12 @@ fi
 
     INITRD_TARGET="/boot/initramfs-$KVER_DIR.img"
 
-    # The distro's own kernel-package hook may have already dropped a
-    # differently-named initramfs in /boot (e.g. a pkgbase-named image built
-    # before this regen, with no btrfs support). install_distro_systemd_boot/
-    # install_distro_limine pick their INITRD_FILE via an unordered
-    # `find | head -n1` over the same glob, so a stale leftover here could be
-    # silently selected instead of the one we're about to (re)generate below.
+    # Clear stale initramfs-*.img so the bootloader steps' unordered
+    # `find | head -n1` can't pick a non-btrfs leftover instead of ours.
     find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" ! -name "$(basename "$INITRD_TARGET")" -delete
 
-    # -N (no-hostonly) is vital to generate the image correctly from within the chroot.
-    # Explicit outfile is required: Garuda's dracut.conf.d defaults to the BLS/
-    # machine-id layout under /boot/efi/<machine-id>/<kver>/, which doesn't exist
-    # yet at this point in the install and makes dracut fail outright. Naming it
-    # explicitly matches what install_distro_systemd_boot/install_distro_limine
-    # already search for (initramfs-*.img under /boot).
+    # -N (no-hostonly) is vital to generate the image correctly from within the chroot
+    # Explicit outfile: Garuda's dracut.conf.d defaults to a BLS path that doesn't exist yet.
     if ! dracut -N -f --add "btrfs" --kver "$KVER_DIR" "$INITRD_TARGET"; then
         echo "[FATAL ERROR] dracut failed to generate $INITRD_TARGET"
         exit 1


### PR DESCRIPTION
## Summary
- Without an explicit outfile, `dracut` on Garuda defaults to its `dracut.conf.d`-configured BLS/machine-id layout under `/boot/efi/<machine-id>/<kver>/`, which doesn't exist yet at this point in the install — dracut fails outright. The chroot runner's non-fatal step handling catches it, so the Calamares install still reports success even though no btrfs-capable initramfs was ever generated.
- Pins the output to `/boot/initramfs-$KVER_DIR.img`, matching the naming `install_distro_systemd_boot`/`install_distro_limine` already search for.
- Also hardened per code review: removes any stale `initramfs-*.img` the distro's own kernel-package hook may have already dropped in `/boot` before regenerating (the bootloader steps pick their initrd via an unordered `find | head -n1`, so a leftover non-btrfs file could otherwise be silently selected instead), and fails loudly if dracut itself fails or doesn't produce the expected file.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] Root-caused via a real Calamares install log (`install-initramfs` step failing with `dracut[F]: Can't write to /boot/efi/<machine-id>/<kver>: Directory ... does not exist`)
- [x] End-to-end verified: fresh Garuda + btrfs install now completes with `install-initramfs`/`install-bootloader` both succeeding (`Exit code: 0`, was `1` before), and the installed system boots cleanly into the desktop with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)