### PR TITLE
fix: archiso live-boot failures on CachyOS (missing modules, wrong kernel, silent bootloader/teardown failures)

### DIFF
--- a/coa/brain.d/modules/alpine.bash.tmpl
+++ b/coa/brain.d/modules/alpine.bash.tmpl
@@ -48,7 +48,9 @@ mkinitfs -o /boot/initramfs-$KVER $KVER
 
 {{ define "install_distro_bootloader" }}
 if [ -d /sys/firmware/efi ]; then
-    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=alpine --recheck
+    if ! grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=alpine --recheck; then
+        [ -f /boot/efi/EFI/alpine/grubx64.efi ] || { echo "[FATAL ERROR] grub-install failed and no EFI binary was written"; exit 1; }
+    fi
 
     # Removable fallback: firmware (notably some VM/OVMF setups) with no
     # NVRAM entry falls back to EFI/BOOT/BOOTX64.EFI.

--- a/coa/brain.d/modules/alpine.bash.tmpl
+++ b/coa/brain.d/modules/alpine.bash.tmpl
@@ -48,8 +48,7 @@ mkinitfs -o /boot/initramfs-$KVER $KVER
 
 {{ define "install_distro_bootloader" }}
 if [ -d /sys/firmware/efi ]; then
-    # Tolerate NVRAM-only failures so the fallback below still runs.
-    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=alpine --recheck || echo "-> WARNING: grub-install failed, trying removable fallback anyway..."
+    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=alpine --recheck
 
     # Removable fallback: firmware (notably some VM/OVMF setups) with no
     # NVRAM entry falls back to EFI/BOOT/BOOTX64.EFI.

--- a/coa/brain.d/modules/alpine.bash.tmpl
+++ b/coa/brain.d/modules/alpine.bash.tmpl
@@ -42,7 +42,8 @@ cp "$LIVEROOT/boot/initramfs-penguins-eggs" "$ISODIR/live/initrd.img"
 # 🎯 INSTALLER
 # ==============================================================================
 {{ define "install_distro_initramfs" }}
-KVER=$(ls -1 /lib/modules/ | head -n 1)
+KVER=$(uname -r)
+[ -d "/lib/modules/$KVER" ] || KVER=$(ls -1 /lib/modules/ | head -n 1)
 mkinitfs -o /boot/initramfs-$KVER $KVER
 {{ end }}
 

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -263,7 +263,7 @@ fi
 
 if [ -d /sys/firmware/efi ] && grep -q "/boot/efi" /proc/mounts; then
     echo "-> UEFI installation..."
-    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id={{ .DistroID }} --recheck || echo "-> WARNING: grub-install failed, trying removable fallback anyway..."
+    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id={{ .DistroID }} --recheck
 
     mkdir -p /boot/efi/EFI/BOOT
     [ -f "/boot/efi/EFI/{{ .DistroID }}/grubx64.efi" ] && cp -f "/boot/efi/EFI/{{ .DistroID }}/grubx64.efi" /boot/efi/EFI/BOOT/BOOTX64.EFI

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -99,7 +99,12 @@ EOF
     # both a regular and an -lts kernel installed, picking the alphabetically
     # first /lib/modules entry silently built the initramfs for the wrong one.
     KERNEL_VERSION=$(uname -r)
-    
+    if [ ! -d "/lib/modules/$KERNEL_VERSION" ]; then
+        # Fall back if uname -r doesn't match an installed kernel (e.g. an
+        # unrebooted upgrade) - matches whichever kernel is actually present.
+        KERNEL_VERSION=$(ls -1 /lib/modules | grep -E '^[0-9]' | head -n 1)
+    fi
+
     echo "-> Generating unique live initramfs for kernel $KERNEL_VERSION..."
     mkinitcpio -c /etc/mkinitcpio.conf -k "$KERNEL_VERSION" -g "/boot/oa-initrd.img"
 {{ end }}
@@ -353,8 +358,13 @@ if [ ! -f "$KERNEL_PATH" ]; then
     KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
 fi
 
-# L'initrd generato poco prima da dracut o mkinitcpio sarà in /boot
-INITRD_PATH=$(find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" -type f | head -n 1)
+# L'initrd generato poco prima da dracut o mkinitcpio sarà in /boot;
+# lo cerchiamo per pkgbase così corrisponde allo stesso kernel di KERNEL_PATH.
+PKGBASE=$(cat "/usr/lib/modules/$(uname -r)/pkgbase" 2>/dev/null || echo "linux")
+INITRD_PATH="/boot/initramfs-$PKGBASE.img"
+if [ ! -f "$INITRD_PATH" ]; then
+    INITRD_PATH=$(find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" -type f | head -n 1)
+fi
 
 if [ -z "$KERNEL_PATH" ] || [ -z "$INITRD_PATH" ]; then
     echo "[FATAL ERROR] Unable to determine the installed kernel or initrd in the chroot."
@@ -416,7 +426,12 @@ if [ ! -f "$KERNEL_PATH" ]; then
     KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
 fi
 
-INITRD_PATH=$(find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" -type f | head -n 1)
+# Cerchiamo l'initrd per pkgbase così corrisponde allo stesso kernel di KERNEL_PATH.
+PKGBASE=$(cat "/usr/lib/modules/$(uname -r)/pkgbase" 2>/dev/null || echo "linux")
+INITRD_PATH="/boot/initramfs-$PKGBASE.img"
+if [ ! -f "$INITRD_PATH" ]; then
+    INITRD_PATH=$(find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" -type f | head -n 1)
+fi
 
 if [ -z "$KERNEL_PATH" ] || [ -z "$INITRD_PATH" ]; then
     echo "[FATAL ERROR] Unable to determine the kernel or initrd for Limine."

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -73,7 +73,7 @@ echo "-> Preparing Initramfs configuration for Live (Arch Family)..."
         fi
         cat << 'EOF' > /etc/mkinitcpio.conf
 MODULES=(loop dm-snapshot btrfs)
-HOOKS=(base udev microcode modconf kms miso miso_loop_mnt block keyboard keymap consolefont filesystems fsck)
+HOOKS=(base udev microcode modconf kms miso miso_loop_mnt block keyboard keymap consolefont filesystems)
 COMPRESSION="zstd"
 EOF
     {{ else }}
@@ -90,7 +90,7 @@ EOF
         
         cat << 'EOF' > /etc/mkinitcpio.conf
 MODULES=(loop dm-snapshot btrfs)
-HOOKS=(base udev microcode modconf kms archiso archiso_loop_mnt block filesystems keyboard keymap consolefont fsck)
+HOOKS=(base udev microcode modconf kms archiso archiso_loop_mnt block filesystems keyboard keymap consolefont)
 COMPRESSION="zstd"      
 EOF
     {{ end }}

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -265,7 +265,12 @@ fi
 
 if [ -d /sys/firmware/efi ] && grep -q "/boot/efi" /proc/mounts; then
     echo "-> UEFI installation..."
-    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id={{ .DistroID }} --recheck
+    if ! grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id={{ .DistroID }} --recheck; then
+        # NVRAM-registration can fail (e.g. OVMF/VM firmware) even though the
+        # EFI binary was written correctly; only abort if it genuinely wasn't.
+        [ -f "/boot/efi/EFI/{{ .DistroID }}/grubx64.efi" ] || { echo "[FATAL ERROR] grub-install failed and no EFI binary was written"; exit 1; }
+        echo "-> WARNING: grub-install failed (likely NVRAM-only); EFI binary is present, continuing with removable fallback."
+    fi
 
     mkdir -p /boot/efi/EFI/BOOT
     [ -f "/boot/efi/EFI/{{ .DistroID }}/grubx64.efi" ] && cp -f "/boot/efi/EFI/{{ .DistroID }}/grubx64.efi" /boot/efi/EFI/BOOT/BOOTX64.EFI

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -95,8 +95,10 @@ COMPRESSION="zstd"
 EOF
     {{ end }}
     
-    # Takes the kernel version from the installed modules IN THE CHROOT, ignoring the host kernel
-    KERNEL_VERSION=$(ls -1 /lib/modules | grep -E '^[0-9]' | head -n 1)
+    # Must match distro_copy_kernel_cmd's kernel selection (uname -r): with
+    # both a regular and an -lts kernel installed, picking the alphabetically
+    # first /lib/modules entry silently built the initramfs for the wrong one.
+    KERNEL_VERSION=$(uname -r)
     
     echo "-> Generating unique live initramfs for kernel $KERNEL_VERSION..."
     mkinitcpio -c /etc/mkinitcpio.conf -k "$KERNEL_VERSION" -g "/boot/oa-initrd.img"

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -358,16 +358,31 @@ if [ ! -f "$KERNEL_PATH" ]; then
     KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
 fi
 
-# L'initrd generato poco prima da dracut o mkinitcpio sarà in /boot;
-# lo cerchiamo per pkgbase così corrisponde allo stesso kernel di KERNEL_PATH.
-PKGBASE=$(cat "/usr/lib/modules/$(uname -r)/pkgbase" 2>/dev/null || echo "linux")
-INITRD_PATH="/boot/initramfs-$PKGBASE.img"
-if [ ! -f "$INITRD_PATH" ]; then
+if [ -z "$KERNEL_PATH" ] || [ ! -f "$KERNEL_PATH" ]; then
+    echo "[FATAL ERROR] Unable to determine the installed kernel in the chroot."
+    exit 1
+fi
+
+# L'initrd va derivato dal kernel EFFETTIVAMENTE risolto sopra, non da una
+# ricerca indipendente: se uname -r non corrisponde (es. chroot d'installazione
+# con kernel diverso da quello live), le due ricerche potrebbero altrimenti
+# scegliere due kernel diversi (visto su CachyOS con linux-cachyos/-lts).
+case "$KERNEL_PATH" in
+    /usr/lib/modules/*/vmlinuz)
+        KVER=$(basename "$(dirname "$KERNEL_PATH")")
+        PKGBASE=$(cat "/usr/lib/modules/$KVER/pkgbase" 2>/dev/null || echo "$KVER")
+        INITRD_PATH="/boot/initramfs-$PKGBASE.img"
+        ;;
+    /boot/vmlinuz-*)
+        INITRD_PATH="/boot/initramfs-${KERNEL_PATH#/boot/vmlinuz-}.img"
+        ;;
+esac
+if [ -z "$INITRD_PATH" ] || [ ! -f "$INITRD_PATH" ]; then
     INITRD_PATH=$(find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" -type f | head -n 1)
 fi
 
-if [ -z "$KERNEL_PATH" ] || [ -z "$INITRD_PATH" ]; then
-    echo "[FATAL ERROR] Unable to determine the installed kernel or initrd in the chroot."
+if [ -z "$INITRD_PATH" ]; then
+    echo "[FATAL ERROR] Unable to determine the installed initrd in the chroot."
     exit 1
 fi
 
@@ -426,15 +441,31 @@ if [ ! -f "$KERNEL_PATH" ]; then
     KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
 fi
 
-# Cerchiamo l'initrd per pkgbase così corrisponde allo stesso kernel di KERNEL_PATH.
-PKGBASE=$(cat "/usr/lib/modules/$(uname -r)/pkgbase" 2>/dev/null || echo "linux")
-INITRD_PATH="/boot/initramfs-$PKGBASE.img"
-if [ ! -f "$INITRD_PATH" ]; then
+if [ -z "$KERNEL_PATH" ] || [ ! -f "$KERNEL_PATH" ]; then
+    echo "[FATAL ERROR] Unable to determine the kernel for Limine."
+    exit 1
+fi
+
+# L'initrd va derivato dal kernel EFFETTIVAMENTE risolto sopra, non da una
+# ricerca indipendente: se uname -r non corrisponde (es. chroot d'installazione
+# con kernel diverso da quello live), le due ricerche potrebbero altrimenti
+# scegliere due kernel diversi (visto su CachyOS con linux-cachyos/-lts).
+case "$KERNEL_PATH" in
+    /usr/lib/modules/*/vmlinuz)
+        KVER=$(basename "$(dirname "$KERNEL_PATH")")
+        PKGBASE=$(cat "/usr/lib/modules/$KVER/pkgbase" 2>/dev/null || echo "$KVER")
+        INITRD_PATH="/boot/initramfs-$PKGBASE.img"
+        ;;
+    /boot/vmlinuz-*)
+        INITRD_PATH="/boot/initramfs-${KERNEL_PATH#/boot/vmlinuz-}.img"
+        ;;
+esac
+if [ -z "$INITRD_PATH" ] || [ ! -f "$INITRD_PATH" ]; then
     INITRD_PATH=$(find /boot -maxdepth 1 -name "initramfs-*.img" ! -name "*fallback*" -type f | head -n 1)
 fi
 
-if [ -z "$KERNEL_PATH" ] || [ -z "$INITRD_PATH" ]; then
-    echo "[FATAL ERROR] Unable to determine the kernel or initrd for Limine."
+if [ -z "$INITRD_PATH" ]; then
+    echo "[FATAL ERROR] Unable to determine the initrd for Limine."
     exit 1
 fi
 

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -72,7 +72,7 @@ echo "-> Preparing Initramfs configuration for Live (Arch Family)..."
             pacman -Sy --noconfirm manjaro-tools-iso || { echo "[FATAL ERROR] Unable to install manjaro-tools-iso"; exit 1; }
         fi
         cat << 'EOF' > /etc/mkinitcpio.conf
-MODULES=(loop dm-snapshot btrfs sr_mod)
+MODULES=(loop dm-snapshot btrfs sr_mod isofs)
 HOOKS=(base udev microcode modconf kms miso miso_loop_mnt block keyboard keymap consolefont filesystems)
 COMPRESSION="zstd"
 EOF
@@ -89,7 +89,7 @@ EOF
         fi
         
         cat << 'EOF' > /etc/mkinitcpio.conf
-MODULES=(loop dm-snapshot btrfs sr_mod)
+MODULES=(loop dm-snapshot btrfs sr_mod isofs)
 HOOKS=(base udev microcode modconf kms archiso archiso_loop_mnt block filesystems keyboard keymap consolefont)
 COMPRESSION="zstd"
 EOF

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -199,7 +199,12 @@ fi
 {{ if or (eq .DistroID "garuda") (eq .DistroID "endeavouros") }}
     echo "-> Regenerating initramfs on Garuda/EndeavourOS via dracut..."
     
-    KVER_DIR=$(ls -1 /lib/modules/ | grep -v "extramodules" | head -n 1)
+    KVER_DIR=$(uname -r)
+    if [ ! -d "/lib/modules/$KVER_DIR" ]; then
+        # Fall back if uname -r doesn't match an installed kernel (e.g. an
+        # unrebooted upgrade) - matches whichever kernel is actually present.
+        KVER_DIR=$(ls -1 /lib/modules/ | grep -v "extramodules" | head -n 1)
+    fi
     if [ -z "$KVER_DIR" ]; then
         echo "[FATAL ERROR] Unable to determine the kernel in the chroot."
         exit 1
@@ -316,8 +321,9 @@ fi
 # =====================================================================
 if ! ls /boot/vmlinuz-* 1> /dev/null 2>&1; then
     echo "-> Nessun kernel trovato in /boot. Cerco nei moduli (layout systemd-boot)..."
-    KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
-    
+    KERNEL_PATH="/usr/lib/modules/$(uname -r)/vmlinuz"
+    [ -f "$KERNEL_PATH" ] || KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
+
     if [ -n "$KERNEL_PATH" ]; then
         # Recupera il nome della versione (es. 6.1.12-arch1-1)
         KVER=$(basename $(dirname "$KERNEL_PATH"))
@@ -337,9 +343,13 @@ echo "-> Installing systemd-boot (bootctl)..."
 bootctl install --esp-path=/boot/efi
 mkdir -p /boot/efi/loader/entries
 
-# Ricerca intelligente del kernel (supporto per layout classico e systemd-boot)
-KERNEL_PATH=$(find /boot -maxdepth 1 -name "vmlinuz-*" -type f | head -n 1)
-if [ -z "$KERNEL_PATH" ]; then
+# Ricerca intelligente del kernel (supporto per layout classico e systemd-boot),
+# preferendo la versione realmente in esecuzione se più kernel sono installati.
+KERNEL_PATH="/usr/lib/modules/$(uname -r)/vmlinuz"
+if [ ! -f "$KERNEL_PATH" ]; then
+    KERNEL_PATH=$(find /boot -maxdepth 1 -name "vmlinuz-*" -type f | head -n 1)
+fi
+if [ ! -f "$KERNEL_PATH" ]; then
     KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
 fi
 
@@ -397,9 +407,12 @@ EOF
 {{ define "install_distro_limine" }}
 echo "-> Installing Limine bootloader (UEFI)..."
 
-# Ricerca intelligente del kernel
-KERNEL_PATH=$(find /boot -maxdepth 1 -name "vmlinuz-*" -type f | head -n 1)
-if [ -z "$KERNEL_PATH" ]; then
+# Ricerca intelligente del kernel, preferendo la versione realmente in esecuzione.
+KERNEL_PATH="/usr/lib/modules/$(uname -r)/vmlinuz"
+if [ ! -f "$KERNEL_PATH" ]; then
+    KERNEL_PATH=$(find /boot -maxdepth 1 -name "vmlinuz-*" -type f | head -n 1)
+fi
+if [ ! -f "$KERNEL_PATH" ]; then
     KERNEL_PATH=$(find /usr/lib/modules -name "vmlinuz" -type f | head -n 1)
 fi
 

--- a/coa/brain.d/modules/arch-family.bash.tmpl
+++ b/coa/brain.d/modules/arch-family.bash.tmpl
@@ -72,7 +72,7 @@ echo "-> Preparing Initramfs configuration for Live (Arch Family)..."
             pacman -Sy --noconfirm manjaro-tools-iso || { echo "[FATAL ERROR] Unable to install manjaro-tools-iso"; exit 1; }
         fi
         cat << 'EOF' > /etc/mkinitcpio.conf
-MODULES=(loop dm-snapshot btrfs)
+MODULES=(loop dm-snapshot btrfs sr_mod)
 HOOKS=(base udev microcode modconf kms miso miso_loop_mnt block keyboard keymap consolefont filesystems)
 COMPRESSION="zstd"
 EOF
@@ -89,9 +89,9 @@ EOF
         fi
         
         cat << 'EOF' > /etc/mkinitcpio.conf
-MODULES=(loop dm-snapshot btrfs)
+MODULES=(loop dm-snapshot btrfs sr_mod)
 HOOKS=(base udev microcode modconf kms archiso archiso_loop_mnt block filesystems keyboard keymap consolefont)
-COMPRESSION="zstd"      
+COMPRESSION="zstd"
 EOF
     {{ end }}
     

--- a/coa/brain.d/modules/debian.bash.tmpl
+++ b/coa/brain.d/modules/debian.bash.tmpl
@@ -51,7 +51,9 @@ update-initramfs -u
 
 {{ define "install_distro_bootloader" }}
 if [ -d /sys/firmware/efi ]; then
-    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=oa-live --recheck
+    if ! grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=oa-live --recheck; then
+        [ -f /boot/efi/EFI/oa-live/grubx64.efi ] || { echo "[FATAL ERROR] grub-install failed and no EFI binary was written"; exit 1; }
+    fi
 
     # Removable fallback: firmware (notably some VM/OVMF setups) with no
     # NVRAM entry falls back to EFI/BOOT/BOOTX64.EFI.

--- a/coa/brain.d/modules/debian.bash.tmpl
+++ b/coa/brain.d/modules/debian.bash.tmpl
@@ -51,8 +51,7 @@ update-initramfs -u
 
 {{ define "install_distro_bootloader" }}
 if [ -d /sys/firmware/efi ]; then
-    # Tolerate NVRAM-only failures so the fallback below still runs.
-    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=oa-live --recheck || echo "-> WARNING: grub-install failed, trying removable fallback anyway..."
+    grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=oa-live --recheck
 
     # Removable fallback: firmware (notably some VM/OVMF setups) with no
     # NVRAM entry falls back to EFI/BOOT/BOOTX64.EFI.

--- a/coa/pkg/cmd/destroy.go
+++ b/coa/pkg/cmd/destroy.go
@@ -41,7 +41,7 @@ func handledestroy() {
 	utils.LogNormal("Freeing the nest...")
 
 	if err := utils.Exec("oa cleanup"); err != nil {
-		utils.LogError("Cleanup (unmount) failed: %v", err)
+		utils.Fatal("Cleanup (unmount) failed: %v - refusing to remove the workspace while mounts may still be attached; inspect and unmount manually before retrying.", err)
 	}
 
 	workPath := pathDefaults.DefaultWorkPath

--- a/oa/src/eternit.c
+++ b/oa/src/eternit.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <unistd.h>
 #include <sys/mount.h>
 #include "cJSON.h"
 #include "logger.h"
@@ -20,6 +22,32 @@ static const char* get_json_string(cJSON *obj, const char *key, const char *fall
         return item->valuestring;
     }
     return fallback;
+}
+
+// Blocking umount with a short EBUSY retry budget, falling back to lazy
+// MNT_DETACH only if still busy after retrying (a lazy detach can leave
+// the backing store reclaiming after this returns, racing a remaster
+// that immediately reuses the same work_dir).
+static void umount_path(const char *path) {
+    if (umount(path) == 0) return;
+    if (errno != EBUSY) {
+        LOG_WARN("⚠️  [eternit] umount('%s') failed: %s", path, strerror(errno));
+        return;
+    }
+
+    for (int attempt = 0; attempt < 10; attempt++) {
+        usleep(100000); // 100ms
+        if (umount(path) == 0) return;
+        if (errno != EBUSY) {
+            LOG_WARN("⚠️  [eternit] umount('%s') failed: %s", path, strerror(errno));
+            return;
+        }
+    }
+
+    LOG_WARN("⚠️  [eternit] '%s' still busy after retries, forcing lazy detach", path);
+    if (umount2(path, MNT_DETACH) != 0) {
+        LOG_ERR("❌ [eternit] lazy detach of '%s' failed: %s", path, strerror(errno));
+    }
 }
 
 // Main dynamic unmount function
@@ -62,14 +90,16 @@ int run_eternit_umount(cJSON *task) {
 
     LOG_INFO("☣️  [eternit] Environmental decontamination initiated: Found %d mount points in %s", count, work_dir);
     
-    // Surgical dismantling
+    // Surgical dismantling: block until each unmount actually completes,
+    // so the caller can trust work_dir is safe to reuse immediately.
     for (int i = 0; i < count; i++) {
-        // LOG_INFO("   -> Isolating and extracting: %s", mounts[i]);
-        umount2(mounts[i], MNT_DETACH);
+        umount_path(mounts[i]);
         free(mounts[i]);
     }
-    
+
     if (mounts) free(mounts);
+
+    sync();
 
     LOG_INFO("✅ [eternit] Area secured. Decontamination completed for: %s", work_dir);
     return 0;

--- a/oa/src/eternit.c
+++ b/oa/src/eternit.c
@@ -28,26 +28,28 @@ static const char* get_json_string(cJSON *obj, const char *key, const char *fall
 // MNT_DETACH only if still busy after retrying (a lazy detach can leave
 // the backing store reclaiming after this returns, racing a remaster
 // that immediately reuses the same work_dir).
-static void umount_path(const char *path) {
-    if (umount(path) == 0) return;
+static int umount_path(const char *path) {
+    if (umount(path) == 0) return 0;
     if (errno != EBUSY) {
         LOG_WARN("⚠️  [eternit] umount('%s') failed: %s", path, strerror(errno));
-        return;
+        return -1;
     }
 
     for (int attempt = 0; attempt < 10; attempt++) {
         usleep(100000); // 100ms
-        if (umount(path) == 0) return;
+        if (umount(path) == 0) return 0;
         if (errno != EBUSY) {
             LOG_WARN("⚠️  [eternit] umount('%s') failed: %s", path, strerror(errno));
-            return;
+            return -1;
         }
     }
 
     LOG_WARN("⚠️  [eternit] '%s' still busy after retries, forcing lazy detach", path);
     if (umount2(path, MNT_DETACH) != 0) {
         LOG_ERR("❌ [eternit] lazy detach of '%s' failed: %s", path, strerror(errno));
+        return -1;
     }
+    return 0;
 }
 
 // Main dynamic unmount function
@@ -92,14 +94,20 @@ int run_eternit_umount(cJSON *task) {
     
     // Surgical dismantling: block until each unmount actually completes,
     // so the caller can trust work_dir is safe to reuse immediately.
+    int had_failure = 0;
     for (int i = 0; i < count; i++) {
-        umount_path(mounts[i]);
+        if (umount_path(mounts[i]) != 0) had_failure = 1;
         free(mounts[i]);
     }
 
     if (mounts) free(mounts);
 
     sync();
+
+    if (had_failure) {
+        LOG_ERR("❌ [eternit] Decontamination incomplete for: %s", work_dir);
+        return 1;
+    }
 
     LOG_INFO("✅ [eternit] Area secured. Decontamination completed for: %s", work_dir);
     return 0;

--- a/oa/src/main.c
+++ b/oa/src/main.c
@@ -163,8 +163,10 @@ int main(int argc, char **argv) {
             // FRENO DI EMERGENZA!
             LOG_ERR("🚨 [oa-main] FATAL ERROR: Task '%s' failed. Aborting immediately!", task_name);
             error_count++;
-            perform_safety_teardown(current_work_dir);
-            break; 
+            if (perform_safety_teardown(current_work_dir) != 0) {
+                LOG_ERR("❌ [oa-main] Emergency teardown also failed to fully unmount %s.", current_work_dir);
+            }
+            break;
         }
     }
 
@@ -178,8 +180,12 @@ int main(int argc, char **argv) {
         LOG_ERR("❌ [oa-main] Execution ABORTED due to an error. Successes: %d, Errors: %d", success_count, error_count);
     } else {
         LOG_INFO("✨ [oa-main] ISO build completed. Handing over the area to the decontamination team...");
-        perform_safety_teardown(current_work_dir);
-        LOG_INFO("🏁 [oa-main] Site successfully dismantled. Successes: %d, Errors: 0", success_count);
+        if (perform_safety_teardown(current_work_dir) != 0) {
+            LOG_ERR("❌ [oa-main] Final decontamination failed - %s may still have live mounts.", current_work_dir);
+            error_count++;
+        } else {
+            LOG_INFO("🏁 [oa-main] Site successfully dismantled. Successes: %d, Errors: 0", success_count);
+        }
     }
 
     oa_close_log();


### PR DESCRIPTION
## Summary

Found and fixed via live debugging a CachyOS live ISO that wouldn't boot. Root cause turned out to be a kernel-version-selection bug that also masked/produced several other latent issues along the way.

- **Live boot fixes (arch-family)**
  - Drop the `fsck` mkinitcpio hook on live media — it can't resolve `root=` on a squashfs+overlay live system and prints a harmless-looking but confusing error on every boot.
  - Bundle `sr_mod`/`isofs` into the live initramfs `MODULES=` — were missing, breaking boot from certain media/controller combinations.
  - **Root cause**: `KERNEL_VERSION` was picked via `ls -1 /lib/modules | head -n1` (alphabetically-first), not `uname -r`. With both a regular and an `-lts` kernel installed (e.g. CachyOS's `linux-cachyos` + `linux-cachyos-lts`), this silently built the initramfs for the *wrong, non-running* kernel — every module bundled above landed in a directory the live kernel never looks at. Fixed at the original site plus 5 other call sites in the same file (and one in Alpine's) that had the identical hazard.

- **Bootloader install (all distros)**
  - `grub-install` failures were silently swallowed (`|| echo WARNING`), so a genuinely broken bootloader install could still report success. Now hard-fails — but only when the EFI binary genuinely wasn't written, so a legitimate NVRAM-registration-only failure (common on OVMF/VM firmware) still falls through to the existing removable-media fallback instead of aborting the whole build.

- **`destroy`/teardown reliability**
  - `oa`'s unmount teardown used a fire-and-forget lazy `MNT_DETACH` with no return-value check, so a genuinely stuck mount was invisible to callers - `coa destroy` immediately after could `rm -rf` a directory that still had live mounts under it, and a subsequent `remaster` could land mid-teardown. Reworked to block on `umount()` with a bounded EBUSY retry, only falling back to lazy detach as a last resort, and propagating real failure through the return value all the way up: `coa destroy` now refuses to remove the workspace on failure instead of deleting it anyway, and `oa`'s own build pipeline now reflects a failed final teardown in its exit code instead of reporting success regardless.

- **Follow-up correctness fixes** (found reviewing the above): the `KERNEL_PATH` fix for `install_distro_systemd_boot`/`install_distro_limine` left the paired `INITRD_PATH` on the old heuristic, which could make kernel/initrd mismatches *more* likely than before; fixed by resolving the initrd via the same kernel's `pkgbase`.

## Test plan
- [x] Both `oa` (C, `gcc -Wall -Wextra`) and `coa` (Go) build clean with no warnings
- [x] Live-booted the resulting CachyOS ISO end-to-end (via virtio-blk and via spice/GUI) after the kernel-version fix — confirmed boots to desktop
- [x] Confirmed `destroy` → `remaster` no longer needs a second attempt to get a working bootloader (previously flaky first-run-after-destroy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)