### PR TITLE
fix: bind-mount liveroot onto itself before chroot

### DIFF
--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -18,7 +18,14 @@ mkdir -p "$LIVEROOT" "$OVERLAY/upperdir" "$OVERLAY/workdir" "$OVERLAY/lowerdir"
 # il suo CheckSpace fallisce con "could not determine root mount point /"
 # / "not enough free disk space", anche a disco vuoto (comportamento noto
 # di pacman/libalpm; arch-chroot applica lo stesso workaround).
-mountpoint -q "$LIVEROOT" || mount --bind "$LIVEROOT" "$LIVEROOT"
+# --make-private e' fondamentale: senza, il bind eredita la propagazione
+# "shared" di /home e ogni mount fatto dopo sotto LIVEROOT (proc, sys,
+# dev, usr, ...) si propaga nel suo peer group invece di restare isolato,
+# rendendo poi l'umount di eternit fallire con EINVAL in fase di pulizia.
+if ! mountpoint -q "$LIVEROOT"; then
+    mount --bind "$LIVEROOT" "$LIVEROOT"
+    mount --make-private "$LIVEROOT"
+fi
 
 # 2. COPIE FISICHE
 cp -a /etc /boot "$LIVEROOT/"

--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -22,10 +22,11 @@ mkdir -p "$LIVEROOT" "$OVERLAY/upperdir" "$OVERLAY/workdir" "$OVERLAY/lowerdir"
 # "shared" di /home e ogni mount fatto dopo sotto LIVEROOT (proc, sys,
 # dev, usr, ...) si propaga nel suo peer group invece di restare isolato,
 # rendendo poi l'umount di eternit fallire con EINVAL in fase di pulizia.
-if ! mountpoint -q "$LIVEROOT"; then
-    mount --bind "$LIVEROOT" "$LIVEROOT"
-    mount --make-private "$LIVEROOT"
-fi
+# make-private e' fuori dal guard: e' idempotente, e se un run precedente
+# e' stato interrotto tra il bind e il make-private, mountpoint -q vede
+# gia' un mount e salterebbe per sempre il make-private altrimenti.
+mountpoint -q "$LIVEROOT" || mount --bind "$LIVEROOT" "$LIVEROOT"
+mount --make-private "$LIVEROOT"
 
 # 2. COPIE FISICHE
 cp -a /etc /boot "$LIVEROOT/"

--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -12,19 +12,11 @@ OVERLAY="$BASEPATH/.overlay"
 # 1. SETUP STRUTTURA
 mkdir -p "$LIVEROOT" "$OVERLAY/upperdir" "$OVERLAY/workdir" "$OVERLAY/lowerdir"
 
-# 1.1. SELF-BIND DI LIVEROOT
-# Senza questo, dentro il chroot "/" non compare come mountpoint in
-# /proc/self/mounts: pacman non riesce a determinarne il filesystem e
-# il suo CheckSpace fallisce con "could not determine root mount point /"
-# / "not enough free disk space", anche a disco vuoto (comportamento noto
-# di pacman/libalpm; arch-chroot applica lo stesso workaround).
-# --make-private e' fondamentale: senza, il bind eredita la propagazione
-# "shared" di /home e ogni mount fatto dopo sotto LIVEROOT (proc, sys,
-# dev, usr, ...) si propaga nel suo peer group invece di restare isolato,
-# rendendo poi l'umount di eternit fallire con EINVAL in fase di pulizia.
-# make-private e' fuori dal guard: e' idempotente, e se un run precedente
-# e' stato interrotto tra il bind e il make-private, mountpoint -q vede
-# gia' un mount e salterebbe per sempre il make-private altrimenti.
+# 1.1. SELF-BIND OF LIVEROOT
+# Needed so pacman sees "/" as a mountpoint inside the chroot (otherwise
+# CheckSpace fails outright). make-private stops the bind from propagating
+# onto /home and breaking eternit's umount later. Run outside the guard
+# since it's idempotent and mountpoint alone can't tell shared from private.
 mountpoint -q "$LIVEROOT" || mount --bind "$LIVEROOT" "$LIVEROOT"
 mount --make-private "$LIVEROOT"
 

--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -12,6 +12,14 @@ OVERLAY="$BASEPATH/.overlay"
 # 1. SETUP STRUTTURA
 mkdir -p "$LIVEROOT" "$OVERLAY/upperdir" "$OVERLAY/workdir" "$OVERLAY/lowerdir"
 
+# 1.1. SELF-BIND DI LIVEROOT
+# Senza questo, dentro il chroot "/" non compare come mountpoint in
+# /proc/self/mounts: pacman non riesce a determinarne il filesystem e
+# il suo CheckSpace fallisce con "could not determine root mount point /"
+# / "not enough free disk space", anche a disco vuoto (comportamento noto
+# di pacman/libalpm; arch-chroot applica lo stesso workaround).
+mountpoint -q "$LIVEROOT" || mount --bind "$LIVEROOT" "$LIVEROOT"
+
 # 2. COPIE FISICHE
 cp -a /etc /boot "$LIVEROOT/"
 for link in vmlinuz initrd.img vmlinuz.old initrd.img.old; do


### PR DESCRIPTION
## Summary
- `bootstrap-liveroot.sh` bind-mounted every subdir under the live-remaster chroot (`bin`, `usr`, `proc`, `dev`, ...) individually but never mounted `$LIVEROOT` itself, so `pacman`'s `CheckSpace` check inside the chroot couldn't find `/` in `/proc/self/mounts` and failed with `could not determine root mount point /` / `not enough free disk space` regardless of actual free space (hit while installing `manjaro-tools-iso` on the fly during the `initramfs` task on Manjaro).
- Fixed by bind-mounting `$LIVEROOT` onto itself, matching what `arch-chroot` does for the same reason.
- That self-bind inherited `/home`'s default shared mount propagation, causing every mount created afterward inside the chroot to propagate and making `eternit`'s teardown fail to `umount()` almost all of them with `EINVAL`. Fixed by also running `mount --make-private` on it, again matching `arch-chroot`'s own workaround.
- A follow-up `/code-review` pass caught a crash-recovery gap: `mountpoint -q` can't distinguish "bound" from "bound and private", so if the process was killed between the bind and the make-private call, every later retry would silently skip make-private forever. Fixed by running `make-private` unconditionally (it's idempotent).

## Test plan
- [x] Verified in a Manjaro VM: live remaster completes, ISO builds successfully, all chroot mounts tear down cleanly (no more EINVAL warnings)
- [x] Booted the built ISO, ran the Calamares installer end to end (partition, unpack, bootloader, initramfs), rebooted into the installed system successfully