### PR TITLE
fix: recognize Archcraft, and harden makepkg packaging on Arch derivatives

### DIFF
--- a/coa/brain.d/index.yaml
+++ b/coa/brain.d/index.yaml
@@ -14,6 +14,7 @@ distributions:
   
   - id: "arch"
     like: [
+      "archcraft",
       "cachyos",
       "endeavouros",
       "garuda",

--- a/coa/pkg/builder/packager.go
+++ b/coa/pkg/builder/packager.go
@@ -35,6 +35,18 @@ func packager(ctx sysctx.RuntimeContext, dist string, data RecipeData) {
 		cmd = exec.Command("makepkg", "-s", "-f", "--noconfirm")
 		cmd.Dir = stage
 
+		// Derivatives like BigLinux override PKGDEST/PKGEXT in
+		// /etc/makepkg.conf, moving/renaming the built package out from
+		// under the glob below. Force both, mirroring alpine's REPODEST.
+		absStage, err := filepath.Abs(stage)
+		if err != nil {
+			absStage = stage
+		}
+		cmd.Env = append(os.Environ(),
+			fmt.Sprintf("PKGDEST=%s", absStage),
+			"PKGEXT=.pkg.tar.zst",
+		)
+
 	case "debian":
 		pkgFileName = fmt.Sprintf("penguins-eggs_%s-%s_%s.deb", data.BaseVersion, data.Rel, getDebianArch())
 		finalPath := filepath.Join(ctx.ProjRoot, pkgFileName)


### PR DESCRIPTION
## Summary

**Archcraft distro recognition**
`eggs remaster` failed on Archcraft with `Unable to load Brain Profile: no module found for Arch (ID: archcraft)`. Same class of gap as the earlier RebornOS/CachyOS fixes: Archcraft's `/etc/os-release` `ID` wasn't listed under the arch family's `like` entries in `coa/brain.d/index.yaml` (distro-family detection in `distro.go` already resolved it correctly via `ID_LIKE=arch` — only the separate module-lookup table needed the entry).

**makepkg PKGDEST/PKGEXT hardening**
Hit on BigLinux: `make package` ran `makepkg` to completion successfully, but then failed with `Critical error: packager finished without errors, but package not found in stage!`. Root cause: the arch/manjaro packager case trusted `makepkg`'s default output location, but BigLinux's `/etc/makepkg.conf` sets both a custom `PKGDEST` (moving the package out of `stage`) and `PKGEXT='.pkg.tar'` (no zstd suffix), so the glob looking for the built package never matched. The `alpine` case right above already pins `abuild`'s output via `REPODEST` for the same reason — applied the same fix to `makepkg` via `PKGDEST`/`PKGEXT`, with `stage` forced absolute for safety.

## Test plan
- [x] Verified `eggs remaster` proceeds past brain-profile loading on Archcraft
- [x] Verified `make package` succeeds on BigLinux (re-tested just now, confirmed working)