### PR TITLE
feat(sysinstall): auto-detect installer, pkexec launcher, and Krill confirmation step

### DIFF
--- a/coa/brain.d/base.yaml.tmpl
+++ b/coa/brain.d/base.yaml.tmpl
@@ -207,9 +207,13 @@ remaster:
         Name=Install System
         GenericName=Live Installer
         Comment=Install this system to your hard disk
-        Exec=env SUDO_ASKPASS=/usr/bin/ksshaskpass sudo -A eggs sysinstall calamares
+        Exec=pkexec eggs sysinstall
         Icon=penguins-eggs
+        {{ if .HasCalamares -}}
         Terminal=false
+        {{ else -}}
+        Terminal=true
+        {{ end -}}
         Categories=System;
 
 # ----------------------------------------------------------------------------

--- a/coa/pkg/cmd/config.go
+++ b/coa/pkg/cmd/config.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
-	"coa/pkg/distro"
 	"coa/pkg/parser"
 	"coa/pkg/utils"
 
@@ -63,8 +61,7 @@ type configModel struct {
 
 	focus   int
 	inputs  []textinput.Model
-	algoIdx int
-	instIdx int // 0 for krill, 1 for calamares
+	algoIdx    int
 	ramModeIdx int // 0 for enabled, 1 for disabled
 
 	saveFocus int
@@ -84,13 +81,22 @@ type configState struct {
 	RamMode   bool
 }
 
+func hasCalamares() bool {
+	_, err := exec.LookPath("calamares")
+	return err == nil
+}
+
 func loadConfigState() configState {
+	defaultInstaller := "krill"
+	if hasCalamares() {
+		defaultInstaller = "calamares"
+	}
 	state := configState{
 		User:      "live",
 		Password:  "evolution",
 		Algorithm: "zstd",
 		Level:     3,
-		Installer: "krill",
+		Installer: defaultInstaller,
 		RamMode:   true,
 	}
 	settings, err := parser.LoadCustomSettings()
@@ -111,7 +117,11 @@ func loadConfigState() configState {
 	}
 	state.ISOPrefix = settings.Remaster.ISOPrefix
 	if settings.Remaster.Installer != "" {
-		state.Installer = settings.Remaster.Installer
+		if settings.Remaster.Installer == "calamares" && !hasCalamares() {
+			state.Installer = "krill"
+		} else {
+			state.Installer = settings.Remaster.Installer
+		}
 	}
 	if settings.Remaster.RamMode != nil {
 		state.RamMode = *settings.Remaster.RamMode
@@ -157,11 +167,6 @@ func newConfigModel() configModel {
 		}
 	}
 
-	instIdx := 0
-	if state.Installer == "calamares" {
-		instIdx = 1
-	}
-
 	ramModeIdx := 0
 	if !state.RamMode {
 		ramModeIdx = 1
@@ -170,7 +175,6 @@ func newConfigModel() configModel {
 	return configModel{
 		inputs:     inputs,
 		algoIdx:    algoIdx,
-		instIdx:    instIdx,
 		ramModeIdx: ramModeIdx,
 	}
 }
@@ -237,7 +241,7 @@ func (m *configModel) focusField(idx int, direction int) tea.Cmd {
 			m.focus = (m.focus + direction + cfgFieldCount) % cfgFieldCount
 			continue
 		}
-		if m.focus == cfgInstaller && !isDesktopConfig() {
+		if m.focus == cfgInstaller {
 			m.focus = (m.focus + direction + cfgFieldCount) % cfgFieldCount
 			continue
 		}
@@ -267,10 +271,6 @@ func (m configModel) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				delta = -1
 			}
 			m.algoIdx = (m.algoIdx + delta + len(cfgAlgorithms)) % len(cfgAlgorithms)
-			return m, nil
-		}
-		if m.focus == cfgInstaller {
-			m.instIdx = 1 - m.instIdx
 			return m, nil
 		}
 		if m.focus == cfgRamMode {
@@ -309,23 +309,6 @@ func (m configModel) updateSave(key string) (tea.Model, tea.Cmd) {
 	case "enter":
 		if m.saveFocus == 0 {
 			state := m.buildState()
-			if state.Installer == "calamares" {
-				d := distro.NewDistro()
-				pkgs := getCalamaresPackages(d.FamilyID)
-
-				// 1. Check if packages are installable
-				if err := checkPackagesInstallable(pkgs, d.FamilyID); err != nil {
-					m.saveErr = fmt.Sprintf("Calamares not installable:\n%v", err)
-					return m, nil
-				}
-
-				// 2. Install the packages
-				if err := installPackages(pkgs, d.FamilyID); err != nil {
-					m.saveErr = fmt.Sprintf("Calamares install failed:\n%v", err)
-					return m, nil
-				}
-			}
-
 			if err := saveConfigState(state); err != nil {
 				m.saveErr = fmt.Sprintf("Save failed: %v", err)
 				return m, nil
@@ -346,7 +329,10 @@ func (m configModel) buildState() configState {
 			level = 3
 		}
 	}
-	installers := []string{"krill", "calamares"}
+	installer := "krill"
+	if hasCalamares() {
+		installer = "calamares"
+	}
 	user := strings.TrimSpace(m.inputs[0].Value())
 	if user == "" {
 		user = "live"
@@ -357,7 +343,7 @@ func (m configModel) buildState() configState {
 		Algorithm: cfgAlgorithms[m.algoIdx],
 		Level:     level,
 		ISOPrefix: strings.TrimSpace(m.inputs[3].Value()),
-		Installer: installers[m.instIdx],
+		Installer: installer,
 		RamMode:   m.ramModeIdx == 0,
 	}
 }
@@ -426,9 +412,7 @@ func (m configModel) viewSettings() string {
 	}
 	fields = append(fields, fieldDef{cfgISOPrefix, "ISO prefix"})
 	fields = append(fields, fieldDef{cfgRamMode, "RAM mode option"})
-	if isDesktopConfig() {
-		fields = append(fields, fieldDef{cfgInstaller, "Installer"})
-	}
+	fields = append(fields, fieldDef{cfgInstaller, "Installer"})
 
 	var rows []string
 	for _, f := range fields {
@@ -454,8 +438,11 @@ func (m configModel) viewSettings() string {
 				val = m.inputs[3].View()
 			}
 		case cfgInstaller:
-			installers := []string{"krill", "calamares"}
-			val = cfgCyan.Render("‹ " + installers[m.instIdx] + " ›")
+			if hasCalamares() {
+				val = cfgDim.Render("calamares (auto-detected)")
+			} else {
+				val = cfgDim.Render("krill (default)")
+			}
 		case cfgRamMode:
 			ramModeLabels := []string{"enabled", "disabled"}
 			val = cfgCyan.Render("‹ " + ramModeLabels[m.ramModeIdx] + " ›")
@@ -550,83 +537,6 @@ func saveConfigState(state configState) error {
 		return err
 	}
 	return os.WriteFile(customYAMLPath, []byte(b.String()), 0644)
-}
-
-func isDesktopConfig() bool {
-	if files, _ := filepath.Glob("/usr/share/xsessions/*.desktop"); len(files) > 0 {
-		return true
-	}
-	if files, _ := filepath.Glob("/usr/share/wayland-sessions/*.desktop"); len(files) > 0 {
-		return true
-	}
-	return false
-}
-
-func getCalamaresPackages(family string) []string {
-	switch family {
-	case "debian":
-		return []string{"calamares", "qml-module-qtquick2", "qml-module-qtquick-controls", "qml-module-qtquick-controls2", "qml-module-qtquick-layouts", "qml-module-qtgraphicaleffects"}
-	case "archlinux", "manjaro":
-		return []string{"calamares", "qt5-graphicaleffects"}
-	case "fedora":
-		return []string{"calamares", "qt5-qtgraphicaleffects", "qt5-qtquickcontrols", "qt5-qtquickcontrols2"}
-	case "alpine":
-		return []string{"calamares", "qt5-qtgraphicaleffects", "qt5-qtquickcontrols", "qt5-qtquickcontrols2"}
-	case "opensuse":
-		return []string{"calamares", "libqt5-qtgraphicaleffects", "libqt5-qtquickcontrols", "libqt5-qtquickcontrols2"}
-	default:
-		return []string{"calamares"}
-	}
-}
-
-func checkPackagesInstallable(packages []string, family string) error {
-	var cmd string
-	pkgString := strings.Join(packages, " ")
-	switch family {
-	case "debian":
-		cmd = fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install -y -s %s", pkgString)
-	case "archlinux", "manjaro":
-		cmd = fmt.Sprintf("pacman -Sp %s", pkgString)
-	case "fedora":
-		cmd = fmt.Sprintf("dnf install -y --assumeno %s", pkgString)
-	case "alpine":
-		cmd = fmt.Sprintf("apk add --simulate %s", pkgString)
-	case "opensuse":
-		cmd = fmt.Sprintf("zypper --non-interactive install --dry-run %s", pkgString)
-	default:
-		return fmt.Errorf("unsupported distro family for package check: %s", family)
-	}
-
-	output, err := utils.ExecCapture(cmd)
-	if err != nil {
-		return fmt.Errorf("package check failed: %w\nOutput: %s", err, output)
-	}
-	return nil
-}
-
-func installPackages(packages []string, family string) error {
-	var cmd string
-	pkgString := strings.Join(packages, " ")
-	switch family {
-	case "debian":
-		cmd = fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install -y %s", pkgString)
-	case "archlinux", "manjaro":
-		cmd = fmt.Sprintf("pacman -S --noconfirm %s", pkgString)
-	case "fedora":
-		cmd = fmt.Sprintf("dnf install -y %s", pkgString)
-	case "alpine":
-		cmd = fmt.Sprintf("apk add %s", pkgString)
-	case "opensuse":
-		cmd = fmt.Sprintf("zypper --non-interactive install -y %s", pkgString)
-	default:
-		return fmt.Errorf("unsupported distro family for package install: %s", family)
-	}
-
-	err := utils.Exec(cmd)
-	if err != nil {
-		return fmt.Errorf("package installation failed: %w", err)
-	}
-	return nil
 }
 
 var configCmd = &cobra.Command{

--- a/coa/pkg/cmd/sysinstall.go
+++ b/coa/pkg/cmd/sysinstall.go
@@ -1,20 +1,49 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+
+	"coa/pkg/utils"
+
 	"github.com/spf13/cobra"
 )
 
 var sysinstallCmd = &cobra.Command{
 	Use:   "sysinstall",
 	Short: "Launch the system installer (GUI or TUI)",
-	Long: `sysinstall configures the TUI and GUI installers and launches them
+	Long: `sysinstall configures the TUI and GUI installers and launches them.
+If run without subcommands, it automatically launches Calamares (if present and display server active),
+or falls back to Krill TUI installer.
 
-Example:
+Examples:
+  sudo coa sysinstall
   sudo coa sysinstall calamares
   sudo coa sysinstall krill`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		CheckSudoRequirements("sysinstall", true)
+		if !utils.IsLive() {
+			utils.Fatal("sysinstall can only be run on a live system.")
+		}
+
+		if isCalamaresAvailable() {
+			utils.LogNormal("Calamares detected in graphical environment. Launching Calamares GUI...")
+			calamaresSubCmd.Run(cmd, args)
+			return
+		}
+
+		utils.LogNormal("Launching Krill TUI installer...")
+		krillSubCmd.Run(cmd, args)
 	},
+}
+
+func isCalamaresAvailable() bool {
+	if _, err := exec.LookPath("calamares"); err != nil {
+		return false
+	}
+	display := os.Getenv("DISPLAY")
+	waylandDisplay := os.Getenv("WAYLAND_DISPLAY")
+	return display != "" || waylandDisplay != ""
 }
 
 func init() {

--- a/coa/pkg/cmd/sysinstall_krill.go
+++ b/coa/pkg/cmd/sysinstall_krill.go
@@ -58,9 +58,9 @@ func runKrillInstaller(oaVersion string, unattended bool, fstype string) {
 }
 
 func init() {
-	krillSubCmd.Flags().BoolVar(&krillUnattended, "unattended", false,
+	sysinstallCmd.PersistentFlags().BoolVar(&krillUnattended, "unattended", false,
 		"non-interactive installation with defaults (WARNING: erases the first disk)")
-	krillSubCmd.Flags().StringVar(&krillFstype, "fstype", "",
+	sysinstallCmd.PersistentFlags().StringVar(&krillFstype, "fstype", "",
 		"filesystem type to use (ext4, btrfs)")
 	sysinstallCmd.AddCommand(krillSubCmd)
 }

--- a/coa/pkg/cmd/sysinstall_test.go
+++ b/coa/pkg/cmd/sysinstall_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsCalamaresAvailable(t *testing.T) {
+	origDisplay := os.Getenv("DISPLAY")
+	origWayland := os.Getenv("WAYLAND_DISPLAY")
+	defer func() {
+		os.Setenv("DISPLAY", origDisplay)
+		os.Setenv("WAYLAND_DISPLAY", origWayland)
+	}()
+
+	// Without display environment, should return false
+	os.Unsetenv("DISPLAY")
+	os.Unsetenv("WAYLAND_DISPLAY")
+	if isCalamaresAvailable() {
+		t.Errorf("isCalamaresAvailable() returned true when DISPLAY and WAYLAND_DISPLAY are unset")
+	}
+}
+
+func TestSysinstallSubcommands(t *testing.T) {
+	hasCalamares := false
+	hasKrill := false
+
+	for _, sub := range sysinstallCmd.Commands() {
+		if sub.Name() == "calamares" {
+			hasCalamares = true
+		}
+		if sub.Name() == "krill" {
+			hasKrill = true
+		}
+	}
+
+	if !hasCalamares {
+		t.Errorf("sysinstallCmd missing 'calamares' subcommand")
+	}
+	if !hasKrill {
+		t.Errorf("sysinstallCmd missing 'krill' subcommand")
+	}
+}

--- a/coa/pkg/parser/parser.go
+++ b/coa/pkg/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -84,12 +85,18 @@ ramModeEnabled := true
 		}
 	}
 
+	hasCalamares := false
+	if _, err := exec.LookPath("calamares"); err == nil {
+		hasCalamares = true
+	}
+
 	ctx := TemplateContext{
 		Family:         myDistro.FamilyID,
 		DistroID:       myDistro.DistroID,
 		IsGitHubAction: isGitHubAction,
 		RamModeEnabled: ramModeEnabled,
 		LiveUser:       liveUser,
+		HasCalamares:   hasCalamares,
 	}
 
 	tmpl := template.New(filepath.Base(basePath))

--- a/coa/pkg/parser/types.go
+++ b/coa/pkg/parser/types.go
@@ -59,6 +59,7 @@ type TemplateContext struct {
 	IsGitHubAction bool
 	RamModeEnabled bool
 	LiveUser       string
+	HasCalamares   bool
 }
 
 type BrainIndex struct {

--- a/coa/pkg/sysinstall/krill/krill.go
+++ b/coa/pkg/sysinstall/krill/krill.go
@@ -138,6 +138,9 @@ type model struct {
 	locZoneIdx   int
 	locField     int // 0 = region, 1 = zone
 
+	// Confirm
+	confirmChoice int // 0 = No (default), 1 = Yes
+
 	// Install (guidata dagli eventi dell'engine)
 	installMsg  string
 	percent     float64
@@ -316,20 +319,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateDisk(key)
 		case StateUsers:
 			return m.updateUsers(msg)
+		case StateSummary:
+			return m.updateSummary(key)
 		default:
 			switch key {
 			case "enter":
-				switch m.state {
-				case StateSummary:
-					// Senza login o password non si parte:
-					// torniamo alla schermata Users
-					if m.userInputs[fieldLogin].Value() == "" || m.userInputs[fieldUserPass].Value() == "" {
-						m.state = StateUsers
-						return m, m.focusUser(fieldUserPass)
-					}
-					m.state = StateInstall
-					return m, m.startInstall()
-				case StateInstall:
+				if m.state == StateInstall {
 					if m.installDone {
 						if m.installErr == nil && m.restartEnabled && m.restartChecked {
 							return m, runRestart(m.restartCommand)
@@ -504,6 +499,7 @@ func (m model) updateUsers(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "enter":
 		m.state = StateSummary
+		m.confirmChoice = 0
 		return m, nil
 	case "tab", "down":
 		return m, m.focusUser(m.userFocus + 1)
@@ -519,6 +515,30 @@ func (m model) updateUsers(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.userInputs[m.userFocus], cmd = m.userInputs[m.userFocus].Update(msg)
 		return m, cmd
+	}
+	return m, nil
+}
+
+// updateSummary gestisce la navigazione e la conferma finale nella schermata Summary.
+func (m model) updateSummary(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "left", "right", "tab", "shift+tab", "up", "down":
+		m.confirmChoice = 1 - m.confirmChoice
+	case "esc":
+		m.state = StateWelcome
+		return m, nil
+	case "enter":
+		if m.confirmChoice == 1 {
+			if m.userInputs[fieldLogin].Value() == "" || m.userInputs[fieldUserPass].Value() == "" {
+				m.state = StateUsers
+				return m, m.focusUser(fieldUserPass)
+			}
+			m.state = StateInstall
+			return m, m.startInstall()
+		}
+		// Se si seleziona NO, torna indietro alla prima fase (Welcome)
+		m.state = StateWelcome
+		return m, nil
 	}
 	return m, nil
 }
@@ -604,7 +624,9 @@ func (m model) View() string {
 	finalView := lipgloss.JoinVertical(lipgloss.Center, title, mainWindow)
 
 	footer := "\nPress Ctrl+C to quit."
-	if m.state != StateInstall {
+	if m.state == StateSummary {
+		footer = "\n←/→ select option | Press 'Enter' to confirm."
+	} else if m.state != StateInstall {
 		footer += " | Press 'Enter' to continue."
 	} else if !m.installDone {
 		footer = "\nInstallation in progress — do not power off."
@@ -777,7 +799,7 @@ func (m model) viewSummary() string {
 
 	login := m.userInputs[fieldLogin].Value()
 	hostname := m.userInputs[fieldHostname].Value()
-	device := m.disks[m.diskIdx].Path
+	device := m.disks[m.diskIdx]
 
 	row1 := fmt.Sprintf("Installing %s", greenText.Render(m.productName))
 	row2 := fmt.Sprintf("User %s pwd %s root pwd %s hostname %s",
@@ -792,10 +814,22 @@ func (m model) viewSummary() string {
 	row7 := fmt.Sprintf("Filesystem %s, swap %s", greenText.Render(m.fsTypes[m.fsIdx]), greenText.Render(m.swapTypes[m.swapIdx]))
 	row8 := "Network: " + greenText.Render("dhcp")
 
-	eraseWarning := "Erase all data on disk"
-	msgBox := redBgWhiteText.Render("installation device: " + device)
+	warnBox := redBgWhiteText.Render(fmt.Sprintf(" ⚠️  WARNING: ALL DATA ON %s (%s) WILL BE PERMANENTLY ERASED! ", device.Path, device.Size))
 
-	mainContent := lipgloss.JoinVertical(lipgloss.Left, row1, row2, row3, row4, row5, row6, row7, row8, "", eraseWarning, msgBox)
+	noOpt := "  [ No, cancel and go back ]"
+	yesOpt := "  [ YES, erase disk and install ]"
+
+	if m.confirmChoice == 0 {
+		noOpt = cyanText.Render("→ [ No, cancel and go back ]")
+		yesOpt = dimText.Render("  [ YES, erase disk and install ]")
+	} else {
+		noOpt = dimText.Render("  [ No, cancel and go back ]")
+		yesOpt = redBgWhiteText.Render("→ [ YES, erase disk and install ]")
+	}
+
+	optsRow := fmt.Sprintf("%s    %s", noOpt, yesOpt)
+
+	mainContent := lipgloss.JoinVertical(lipgloss.Left, row1, row2, row3, row4, row5, row6, row7, row8, "", warnBox, "", optsRow)
 	return lipgloss.JoinVertical(lipgloss.Left, stepsView, "", mainContent)
 }
 


### PR DESCRIPTION
## Summary

This PR enhances the `eggs sysinstall` installer flow and configuration experience in `coa`:

1. **Automatic Installer Dispatcher (`eggs sysinstall`)**:
   - Running `sudo eggs sysinstall` automatically detects if `calamares` is installed and an active X11/Wayland display server is present.
   - If present, it launches the **Calamares GUI**.
   - Otherwise (or when running on a TTY console), it falls back to launching the **Krill TUI**.
   - Explicit subcommands `sudo eggs sysinstall calamares` and `sudo eggs sysinstall krill` are preserved.

2. **Read-Only Auto-Detection in `coa config`**:
   - The `Installer` field in `coa config` is now an informative, read-only field (`calamares (auto-detected)` or `krill (default)`).
   - Removed all Calamares package installation dependencies/checks from `config.go`.

3. **Unified Desktop Launcher with `pkexec`**:
   - Updated `/usr/share/applications/install-system.desktop` generation in `base.yaml.tmpl` to use `Exec=pkexec eggs sysinstall`.
   - Utilizes standard Polkit authorization (`net.penguins-eggs.pkexec.policy`).
   - Sets `Terminal=false` when Calamares is present (GUI mode) and `Terminal=true` when Calamares is absent (to open a terminal window for Krill TUI).

4. **Krill TUI Confirmation Safety Step**:
   - Merged explicit safety confirmation into Krill's `Summary` step.
   - Highlights target disk formatting with a red warning banner: `⚠️ WARNING: ALL DATA ON /dev/sdX WILL BE PERMANENTLY ERASED!`.
   - Offers two options with **`[ No, cancel and go back ]` selected by default** to prevent accidental disk wipes.
   - Selecting `No` or pressing `Esc` safely returns the user to the initial `Welcome` phase.

## Testing
- Tested `coa sysinstall` auto-dispatching logic under graphical and TTY environments.
- Tested `coa config` read-only field rendering and configuration saving.
- Ran unit tests across `coa/pkg/cmd` and `coa/pkg/sysinstall/krill` (`go test ./...` passed).