### PR TITLE
feat(calamares): translucent panel behind slideshow text

### DIFF
--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -19,7 +19,7 @@ Presentation
 
     // --- VARIABILI GLOBALI DEL TEMA ---
     property string themeColor: "#C59B27"      // Oro antico
-    property string titleColor: "#D35400"      // Arancio, come l'highlight della sidebar
+    property string titleColor: "#2E8555"      // Verde, come l'header di penguins-eggs.net
     property string shadowColor: "#1a1a1a"     // Ombra scura
     property string textFont: "Helvetica"
     property int textSize: 22

--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -19,7 +19,7 @@ Presentation
 
     // --- VARIABILI GLOBALI DEL TEMA ---
     property string themeColor: "#C59B27"      // Oro antico
-    property string titleColor: "#2E8555"      // Verde, come l'header di penguins-eggs.net
+    property string titleColor: "#D35400"      // Arancio, come l'highlight della sidebar
     property string shadowColor: "#1a1a1a"     // Ombra scura
     property string textFont: "Helvetica"
     property int textSize: 22

--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -204,7 +204,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><h2>Created by Piero Proietti</h2><h4>Issues: github.com/pieroproietti/penguins-eggs/issues</h4><h4>Email: piero.proietti@gmail.com</h4><h4>Website: penguins-eggs.net</h4>")
+                text: qsTr("<h1>penguins-eggs</h1><h2>Created by Piero Proietti</h2><h4>Issues: <font color='#5DADE2'>github.com/pieroproietti/penguins-eggs/issues</font></h4><h4>Email: <font color='#5DADE2'>piero.proietti@gmail.com</font></h4><h4>Website: <font color='#5DADE2'>penguins-eggs.net</font></h4>")
             }
         }
     }

--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -22,6 +22,10 @@ Presentation
     property string shadowColor: "#1a1a1a"     // Ombra scura
     property string textFont: "Helvetica"
     property int textSize: 22
+    property color panelColor: "#000000"       // Vlak achter de tekst
+    property real panelOpacity: 0.45
+    property int panelRadius: 8
+    property int panelMargin: 12
 
     // Sfondo globale per fondere gli eventuali margini con la sidebar
     Rectangle {
@@ -38,9 +42,14 @@ Presentation
             height: Math.min(parent.height, parent.width / (810.0/485.0))
 
             Image { source: "1-reproductive-system.png"; anchors.fill: parent }
+            Rectangle {
+                color: panelColor; opacity: panelOpacity; radius: panelRadius
+                anchors.fill: text1; anchors.margins: -panelMargin
+            }
             Text {
+                id: text1
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter; 
+                anchors.horizontalCenter: parent.horizontalCenter;
                 anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
@@ -57,7 +66,12 @@ Presentation
             height: Math.min(parent.height, parent.width / (810.0/485.0))
 
             Image { source: "2-start-reproduction.png"; anchors.fill: parent }
+            Rectangle {
+                color: panelColor; opacity: panelOpacity; radius: panelRadius
+                anchors.fill: text2; anchors.margins: -panelMargin
+            }
             Text {
+                id: text2
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
                 anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
@@ -75,7 +89,12 @@ Presentation
             height: Math.min(parent.height, parent.width / (810.0/485.0))
 
             Image { source: "3-its-your-system.png"; anchors.fill: parent }
+            Rectangle {
+                color: panelColor; opacity: panelOpacity; radius: panelRadius
+                anchors.fill: text3; anchors.margins: -panelMargin
+            }
             Text {
+                id: text3
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
                 anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
@@ -93,7 +112,12 @@ Presentation
             height: Math.min(parent.height, parent.width / (810.0/485.0))
 
             Image { source: "4-eggs-presentation.png"; anchors.fill: parent }
+            Rectangle {
+                color: panelColor; opacity: panelOpacity; radius: panelRadius
+                anchors.fill: text4; anchors.margins: -panelMargin
+            }
             Text {
+                id: text4
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
                 anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
@@ -111,7 +135,12 @@ Presentation
             height: Math.min(parent.height, parent.width / (810.0/485.0))
 
             Image { source: "5-wait-hatching.png"; anchors.fill: parent }
+            Rectangle {
+                color: panelColor; opacity: panelOpacity; radius: panelRadius
+                anchors.fill: text5; anchors.margins: -panelMargin
+            }
             Text {
+                id: text5
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
                 anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
@@ -129,7 +158,12 @@ Presentation
             height: Math.min(parent.height, parent.width / (810.0/485.0))
 
             Image { source: "6-follow-penguins.png"; anchors.fill: parent }
+            Rectangle {
+                color: panelColor; opacity: panelOpacity; radius: panelRadius
+                anchors.fill: text6; anchors.margins: -panelMargin
+            }
             Text {
+                id: text6
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
                 anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
@@ -147,7 +181,12 @@ Presentation
             height: Math.min(parent.height, parent.width / (810.0/485.0))
 
             Image { source: "7-created-by.png"; anchors.fill: parent }
+            Rectangle {
+                color: panelColor; opacity: panelOpacity; radius: panelRadius
+                anchors.fill: text7; anchors.margins: -panelMargin
+            }
             Text {
+                id: text7
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
                 anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center

--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -51,8 +51,7 @@ Presentation
             Text {
                 id: text1
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter;
-                anchors.top: parent.top; anchors.topMargin: 20
+                anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
                 text: qsTr("<h1>penguins-eggs</h1><br/><h2>eggs: the reproductive system of penguins!</h2>")
@@ -77,7 +76,7 @@ Presentation
             Text {
                 id: text2
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
+                anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
                 text: qsTr("<h1>penguins-eggs</h1><br/><h2>Reproduce your system: pack everything into an egg. You can do it!</h2>")
@@ -102,7 +101,7 @@ Presentation
             Text {
                 id: text3
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
+                anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
                 text: qsTr("<h1>penguins-eggs</h1><br/><h2>Take it anywhere! Boot your environment live or install it on any hardware</h2>")
@@ -127,7 +126,7 @@ Presentation
             Text {
                 id: text4
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
+                anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
                 text: qsTr("<h1>penguins-eggs</h1><br/><h2>It's a CLI tool, but it's simple and intuitive. Just type eggs to get the command list</h2>")
@@ -152,7 +151,7 @@ Presentation
             Text {
                 id: text5
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
+                anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
                 text: qsTr("<h1>penguins-eggs</h1><br/><h3>Please wait, we're hatching...<br/>Don't interrupt the process,<br/>your new penguin will be ready soon!</h3>")
@@ -177,7 +176,7 @@ Presentation
             Text {
                 id: text6
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
+                anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
                 text: qsTr("<h1>penguins-eggs</h1><h3>Join the penguins-eggs development, it's fun!</h3><h3>Use the tool, enjoy it, and collaborate if you want.</h3><br><h3>That's all, folks!</h3>")
@@ -202,7 +201,7 @@ Presentation
             Text {
                 id: text7
                 font.family: textFont; font.pixelSize: textSize; font.bold: true; color: themeColor; style: Text.Outline; styleColor: shadowColor
-                anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
+                anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
                 text: qsTr("<h1>penguins-eggs</h1><h2>Created by Piero Proietti</h2><h4>Issues: github.com/pieroproietti/penguins-eggs/issues</h4><h4>Email: piero.proietti@gmail.com</h4><h4>Website: penguins-eggs.net</h4>")

--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -25,7 +25,7 @@ Presentation
     property color panelColor: "#000000"       // Vlak achter de tekst
     property real panelOpacity: 0.45
     property int panelRadius: 8
-    property int panelMargin: 12
+    property int panelMargin: 6
 
     // Sfondo globale per fondere gli eventuali margini con la sidebar
     Rectangle {
@@ -44,7 +44,9 @@ Presentation
             Image { source: "1-reproductive-system.png"; anchors.fill: parent }
             Rectangle {
                 color: panelColor; opacity: panelOpacity; radius: panelRadius
-                anchors.fill: text1; anchors.margins: -panelMargin
+                width: text1.contentWidth + panelMargin * 2; height: text1.contentHeight + panelMargin * 2
+                anchors.horizontalCenter: text1.horizontalCenter
+                anchors.top: text1.top; anchors.topMargin: -panelMargin
             }
             Text {
                 id: text1
@@ -68,7 +70,9 @@ Presentation
             Image { source: "2-start-reproduction.png"; anchors.fill: parent }
             Rectangle {
                 color: panelColor; opacity: panelOpacity; radius: panelRadius
-                anchors.fill: text2; anchors.margins: -panelMargin
+                width: text2.contentWidth + panelMargin * 2; height: text2.contentHeight + panelMargin * 2
+                anchors.horizontalCenter: text2.horizontalCenter
+                anchors.top: text2.top; anchors.topMargin: -panelMargin
             }
             Text {
                 id: text2
@@ -91,7 +95,9 @@ Presentation
             Image { source: "3-its-your-system.png"; anchors.fill: parent }
             Rectangle {
                 color: panelColor; opacity: panelOpacity; radius: panelRadius
-                anchors.fill: text3; anchors.margins: -panelMargin
+                width: text3.contentWidth + panelMargin * 2; height: text3.contentHeight + panelMargin * 2
+                anchors.horizontalCenter: text3.horizontalCenter
+                anchors.top: text3.top; anchors.topMargin: -panelMargin
             }
             Text {
                 id: text3
@@ -114,7 +120,9 @@ Presentation
             Image { source: "4-eggs-presentation.png"; anchors.fill: parent }
             Rectangle {
                 color: panelColor; opacity: panelOpacity; radius: panelRadius
-                anchors.fill: text4; anchors.margins: -panelMargin
+                width: text4.contentWidth + panelMargin * 2; height: text4.contentHeight + panelMargin * 2
+                anchors.horizontalCenter: text4.horizontalCenter
+                anchors.top: text4.top; anchors.topMargin: -panelMargin
             }
             Text {
                 id: text4
@@ -137,7 +145,9 @@ Presentation
             Image { source: "5-wait-hatching.png"; anchors.fill: parent }
             Rectangle {
                 color: panelColor; opacity: panelOpacity; radius: panelRadius
-                anchors.fill: text5; anchors.margins: -panelMargin
+                width: text5.contentWidth + panelMargin * 2; height: text5.contentHeight + panelMargin * 2
+                anchors.horizontalCenter: text5.horizontalCenter
+                anchors.top: text5.top; anchors.topMargin: -panelMargin
             }
             Text {
                 id: text5
@@ -160,7 +170,9 @@ Presentation
             Image { source: "6-follow-penguins.png"; anchors.fill: parent }
             Rectangle {
                 color: panelColor; opacity: panelOpacity; radius: panelRadius
-                anchors.fill: text6; anchors.margins: -panelMargin
+                width: text6.contentWidth + panelMargin * 2; height: text6.contentHeight + panelMargin * 2
+                anchors.horizontalCenter: text6.horizontalCenter
+                anchors.top: text6.top; anchors.topMargin: -panelMargin
             }
             Text {
                 id: text6
@@ -183,7 +195,9 @@ Presentation
             Image { source: "7-created-by.png"; anchors.fill: parent }
             Rectangle {
                 color: panelColor; opacity: panelOpacity; radius: panelRadius
-                anchors.fill: text7; anchors.margins: -panelMargin
+                width: text7.contentWidth + panelMargin * 2; height: text7.contentHeight + panelMargin * 2
+                anchors.horizontalCenter: text7.horizontalCenter
+                anchors.top: text7.top; anchors.topMargin: -panelMargin
             }
             Text {
                 id: text7
@@ -191,7 +205,7 @@ Presentation
                 anchors.horizontalCenter: parent.horizontalCenter; anchors.top: parent.top; anchors.topMargin: 20
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><h2>Created by Piero Proietti</h2><h4>Issues: <a href='https://github.com/pieroproietti/penguins-eggs/issues'>github.com/pieroproietti/penguins-eggs/issues</a></h4><h4>Email: <a href='mailto:piero.proietti@gmail.com'>piero.proietti@gmail.com</a></h4><h4>Website: <a href='https://penguins-eggs.net'>penguins-eggs.net</a></h4>")
+                text: qsTr("<h1>penguins-eggs</h1><h2>Created by Piero Proietti</h2><h4>Issues: github.com/pieroproietti/penguins-eggs/issues</h4><h4>Email: piero.proietti@gmail.com</h4><h4>Website: penguins-eggs.net</h4>")
             }
         }
     }

--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -19,6 +19,7 @@ Presentation
 
     // --- VARIABILI GLOBALI DEL TEMA ---
     property string themeColor: "#C59B27"      // Oro antico
+    property string titleColor: "#D35400"      // Arancio, come l'highlight della sidebar
     property string shadowColor: "#1a1a1a"     // Ombra scura
     property string textFont: "Helvetica"
     property int textSize: 22
@@ -54,7 +55,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><br/><h2>eggs: the reproductive system of penguins!</h2>")
+                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>eggs: the reproductive system of penguins!</h2>").arg(titleColor)
             }
         }
     }
@@ -79,7 +80,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><br/><h2>Reproduce your system: pack everything into an egg. You can do it!</h2>")
+                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>Reproduce your system: pack everything into an egg. You can do it!</h2>").arg(titleColor)
             }
         }
     }
@@ -104,7 +105,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><br/><h2>Take it anywhere! Boot your environment live or install it on any hardware</h2>")
+                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>Take it anywhere! Boot your environment live or install it on any hardware</h2>").arg(titleColor)
             }
         }
     }
@@ -129,7 +130,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><br/><h2>It's a CLI tool, but it's simple and intuitive. Just type eggs to get the command list</h2>")
+                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>It's a CLI tool, but it's simple and intuitive. Just type eggs to get the command list</h2>").arg(titleColor)
             }
         }
     }
@@ -154,7 +155,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><br/><h3>Please wait, we're hatching...<br/>Don't interrupt the process,<br/>your new penguin will be ready soon!</h3>")
+                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h3>Please wait, we're hatching...<br/>Don't interrupt the process,<br/>your new penguin will be ready soon!</h3>").arg(titleColor)
             }
         }
     }
@@ -179,7 +180,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><h3>Join the penguins-eggs development, it's fun!</h3><h3>Use the tool, enjoy it, and collaborate if you want.</h3><br><h3>That's all, folks!</h3>")
+                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><h3>Join the penguins-eggs development, it's fun!</h3><h3>Use the tool, enjoy it, and collaborate if you want.</h3><br><h3>That's all, folks!</h3>").arg(titleColor)
             }
         }
     }
@@ -204,7 +205,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1>penguins-eggs</h1><h2>Created by Piero Proietti</h2><h4>Issues: github.com/pieroproietti/penguins-eggs/issues</h4><h4>Email: piero.proietti@gmail.com</h4><h4>Website: penguins-eggs.net</h4>")
+                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><h2>Created by Piero Proietti</h2><h4>Issues: github.com/pieroproietti/penguins-eggs/issues</h4><h4>Email: piero.proietti@gmail.com</h4><h4>Website: penguins-eggs.net</h4>").arg(titleColor)
             }
         }
     }

--- a/coa/pkg/assets/calamares_base/branding/eggs/show.qml
+++ b/coa/pkg/assets/calamares_base/branding/eggs/show.qml
@@ -19,7 +19,6 @@ Presentation
 
     // --- VARIABILI GLOBALI DEL TEMA ---
     property string themeColor: "#C59B27"      // Oro antico
-    property string titleColor: "#D35400"      // Arancio, come l'highlight della sidebar
     property string shadowColor: "#1a1a1a"     // Ombra scura
     property string textFont: "Helvetica"
     property int textSize: 22
@@ -55,7 +54,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>eggs: the reproductive system of penguins!</h2>").arg(titleColor)
+                text: qsTr("<h1>penguins-eggs</h1><br/><h2>eggs: the reproductive system of penguins!</h2>")
             }
         }
     }
@@ -80,7 +79,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>Reproduce your system: pack everything into an egg. You can do it!</h2>").arg(titleColor)
+                text: qsTr("<h1>penguins-eggs</h1><br/><h2>Reproduce your system: pack everything into an egg. You can do it!</h2>")
             }
         }
     }
@@ -105,7 +104,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>Take it anywhere! Boot your environment live or install it on any hardware</h2>").arg(titleColor)
+                text: qsTr("<h1>penguins-eggs</h1><br/><h2>Take it anywhere! Boot your environment live or install it on any hardware</h2>")
             }
         }
     }
@@ -130,7 +129,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h2>It's a CLI tool, but it's simple and intuitive. Just type eggs to get the command list</h2>").arg(titleColor)
+                text: qsTr("<h1>penguins-eggs</h1><br/><h2>It's a CLI tool, but it's simple and intuitive. Just type eggs to get the command list</h2>")
             }
         }
     }
@@ -155,7 +154,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><br/><h3>Please wait, we're hatching...<br/>Don't interrupt the process,<br/>your new penguin will be ready soon!</h3>").arg(titleColor)
+                text: qsTr("<h1>penguins-eggs</h1><br/><h3>Please wait, we're hatching...<br/>Don't interrupt the process,<br/>your new penguin will be ready soon!</h3>")
             }
         }
     }
@@ -180,7 +179,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><h3>Join the penguins-eggs development, it's fun!</h3><h3>Use the tool, enjoy it, and collaborate if you want.</h3><br><h3>That's all, folks!</h3>").arg(titleColor)
+                text: qsTr("<h1>penguins-eggs</h1><h3>Join the penguins-eggs development, it's fun!</h3><h3>Use the tool, enjoy it, and collaborate if you want.</h3><br><h3>That's all, folks!</h3>")
             }
         }
     }
@@ -205,7 +204,7 @@ Presentation
                 anchors.centerIn: parent
                 wrapMode: Text.WordWrap; width: parent.width * 0.95; horizontalAlignment: Text.Center
                 textFormat: Text.RichText
-                text: qsTr("<h1><font color='%1'>penguins-eggs</font></h1><h2>Created by Piero Proietti</h2><h4>Issues: github.com/pieroproietti/penguins-eggs/issues</h4><h4>Email: piero.proietti@gmail.com</h4><h4>Website: penguins-eggs.net</h4>").arg(titleColor)
+                text: qsTr("<h1>penguins-eggs</h1><h2>Created by Piero Proietti</h2><h4>Issues: github.com/pieroproietti/penguins-eggs/issues</h4><h4>Email: piero.proietti@gmail.com</h4><h4>Website: penguins-eggs.net</h4>")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add a semi-transparent, rounded panel behind the slideshow text on all 7 slides so gold outline text stays readable against busy photo backgrounds, while the background image still shows through.
- Panel is sized to the actual rendered text content (not the full wrap width), so only the space around the text is covered.
- Text + panel are centered in the slide instead of top-anchored.
- Drop the clickable `<a href>` links on the credits slide (they aren't clickable in the Calamares slideshow anyway) and give the URL/email values a soft blue (`#5DADE2`) that pairs with the gold theme instead of the default hyperlink blue.

Panel color/opacity/radius/margin are exposed as tunable `property` values at the top of `show.qml`.

## Test plan
- [ ] Built ISO and walked through Calamares install in a VM, checked all 7 slides for text legibility and panel sizing
- [ ] Confirmed credits slide URL/email render in the new blue and are still legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)