### PR TITLE
fix: normalize root PATH for external commands

### DIFF
--- a/coa/pkg/utils/exec.go
+++ b/coa/pkg/utils/exec.go
@@ -6,10 +6,24 @@ import (
 	"os/exec"
 )
 
+func ensureRootPath() {
+	if os.Geteuid() != 0 {
+		return
+	}
+
+	const rootPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+	if os.Getenv("PATH") != rootPath {
+		os.Setenv("PATH", rootPath)
+	}
+}
+
 // Exec esegue un comando sh e mostra l'output in tempo reale sul terminale.
 // stdin è collegato al terminale corrente in modo che i programmi interattivi
 // (es. debconf con frontend readline) possano leggere l'input dell'utente.
 func Exec(command string) error {
+	ensureRootPath()
+
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -19,6 +33,8 @@ func Exec(command string) error {
 
 // ExecQuiet esegue un comando senza mostrare nulla (utile per update veloci)
 func ExecQuiet(command string) error {
+	ensureRootPath()
+
 	cmd := exec.Command("sh", "-c", command)
 	return cmd.Run()
 }
@@ -26,6 +42,8 @@ func ExecQuiet(command string) error {
 // ExecCapture esegue un comando e restituisce l'output come stringa
 // Fondamentale per getAvailablePackages (apt-cache pkgnames) ecc.
 func ExecCapture(command string) (string, error) {
+	ensureRootPath()
+
 	var out bytes.Buffer
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &out


### PR DESCRIPTION
## What this fixes

When `coa` runs as root (via `sudo` or `su`), the `PATH` inherited from
the invoking user's shell can be incomplete or altered (e.g. missing
`/usr/sbin` or `/sbin`), depending on how that shell configures its
environment. This caused external commands invoked through `Exec`,
`ExecQuiet` and `ExecCapture` (apt-get, rsync, etc.) to fail with
"command not found" on some systems, even though the binary existed.

## What changes

Adds `ensureRootPath()` in `coa/pkg/utils/exec.go`, called at the start
of `Exec`, `ExecQuiet` and `ExecCapture`. If the process is running as
root (UID 0), it forces a standard, complete `PATH`:

    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

If the process is not running as root, it's a no-op (no change to
normal non-root behavior).

## Why

Low-risk, defensive fix: it doesn't affect non-root processes, and for
root it guarantees system tools (package managers, mount utilities,
etc.) are always found, without depending on how each distro or shell
sets up the inherited PATH.